### PR TITLE
seperate build, dev, prod publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         run: pnpm run manifest:test
 
       - name: Package extension (dev)
-        run: tfx extension create --manifest-globs azure-devops-extension.test.json
+        run: pnpm exec tfx extension create --manifest-globs azure-devops-extension.test.json
 
       - name: Publish to Marketplace (dev)
         uses: jessehouwing/azdo-marketplace@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI / Publish
 
 on:
   push:
-    branches: [main]
+    branches: [ main, dev ]
   pull_request:
-    branches: [main]
+    branches: [ main ]
 
 jobs:
   build-and-test:
@@ -46,6 +46,42 @@ jobs:
             coverage/lcov.info
             coverage/cobertura-coverage.xml
           if-no-files-found: warn
+
+  publish-dev:
+    needs: build-and-test
+    if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build extension
+        run: pnpm run build
+
+      - name: Generate test manifest
+        run: node scripts/create-manifest-variant.cjs test
+
+      - name: Package extension (dev)
+        run: tfx extension create --manifest-globs azure-devops-extension.test.json
+
+      - name: Publish to Marketplace (dev)
+        uses: jessehouwing/azdo-marketplace@v6
+        with:
+          operation: publish
+          token: ${{ secrets.MARKETPLACE_TOKEN }}
+          publisher-id: josephjohnkarl
+          extension-id: ado-tag-manager-develop
+          manifest-file: azure-devops-extension.test.json
 
   publish:
     needs: build-and-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         run: pnpm run build
 
       - name: Generate test manifest
-        run: node scripts/create-manifest-variant.cjs test
+        run: pnpm run manifest:test
 
       - name: Package extension (dev)
         run: tfx extension create --manifest-globs azure-devops-extension.test.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,4 @@ dist/
 .env
 coverage/
 test-results/
-<<<<<<< dev
-=======
 azure-devops-extension.test.json
->>>>>>> main

--- a/package.json
+++ b/package.json
@@ -5,15 +5,10 @@
     "build": "webpack --mode production",
     "dev": "webpack serve --mode development",
     "package": "tfx extension create --manifest-globs azure-devops-extension.json",
-<<<<<<< dev
-    "test": "jest",
-=======
     "manifest:test": "node scripts/create-manifest-variant.cjs test",
-    "package:test": "npm run manifest:test && tfx extension create --manifest-globs azure-devops-extension.test.json",
-    "publish:test": "npm run manifest:test && tfx extension publish --manifest-globs azure-devops-extension.test.json",
+    "package:test": "pnpm run manifest:test && tfx extension create --manifest-globs azure-devops-extension.test.json",
     "test": "jest --runInBand",
     "test:watch": "jest --watch",
->>>>>>> main
     "test:coverage": "jest --coverage"
   },
   "dependencies": {


### PR DESCRIPTION
This pull request updates the CI/CD workflow to support publishing a development version of the extension when changes are pushed to the `dev` branch. It also resolves some inconsistencies in the package scripts to ensure consistent usage of `pnpm` and improves the test script configuration.

**CI/CD Workflow Enhancements:**

* The GitHub Actions workflow in `.github/workflows/ci.yml` is updated to trigger on pushes to both `main` and `dev` branches, allowing for automated processes on development as well as production branches.
* A new `publish-dev` job is added to the workflow, which builds, packages, and publishes a development version of the extension to the Azure DevOps Marketplace when changes are pushed to the `dev` branch. This job uses a separate manifest and extension ID to distinguish it from the production release.

**Package Script Improvements:**

* The `package.json` scripts are updated to consistently use `pnpm` for manifest creation and packaging, and the test script is set to run Jest in-band for more reliable test execution. Merge conflict remnants are also resolved.