### PR TITLE
ci: gate marketplace publish on branch push, not PR builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - main
       - dev
+  push:
+    branches:
+      - main
+      - dev
 
 permissions:
   contents: read
@@ -105,6 +109,7 @@ jobs:
           if-no-files-found: error
 
       - name: Publish from VSIX
+        if: github.event_name == 'push'
         uses: jessehouwing/azdo-marketplace/publish@main
         with:
           auth-type: pat
@@ -114,8 +119,9 @@ jobs:
           no-wait-validation: true
 
       - name: Wait for validation
+        if: github.event_name == 'push'
         uses: jessehouwing/azdo-marketplace/wait-for-validation@main
         with:
           auth-type: pat
           token: ${{ secrets.MARKETPLACE_TOKEN }}
-          vsix-file: ${{ steps.package.outputs.vsix-file }} 
+          vsix-file: ${{ steps.package.outputs.vsix-file }}


### PR DESCRIPTION
## Summary
- Added `push` trigger to `build.yml` so the workflow runs on both PRs and branch merges
- Publish and wait-for-validation steps now only run on `push` events (after merge), not on PR builds
- PRs will only build and test — no accidental marketplace publishes from draft/review PRs

## Test plan
- [ ] Open a PR targeting `dev` or `main` — confirm build/test runs but publish steps are skipped
- [ ] Merge a PR — confirm publish and validation steps execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)