### PR TITLE
feat: inline rename (Feature A) + text search filter (Feature B)

### DIFF
--- a/docs/superpowers/plans/2026-04-17-feature-a-inline-rename.md
+++ b/docs/superpowers/plans/2026-04-17-feature-a-inline-rename.md
@@ -1,0 +1,1215 @@
+# Feature A — Inline Rename Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users rename a tag by double-clicking its name in the table, without leaving the page.
+
+**Architecture:** A new `EditableTagName` component manages its own editing state (view → edit → view). Validation lives in a shared `validateTagName` utility. `TagTable` threads the new optional props through to each name cell. `TagManagerApp` supplies `handleRename`, which calls the existing `tagService.renameTagById` and updates local state on success.
+
+**Tech Stack:** React 16 (functional components + hooks), TypeScript 5, Jest 29, `@testing-library/react` 12, `@testing-library/user-event` 14, `azure-devops-ui` table primitives.
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `src/utils/validateTagName.ts` | Pure function: validates a tag name string, returns `{ valid, reason? }` |
+| Create | `src/utils/validateTagName.test.ts` | Unit tests for the above |
+| Create | `src/utils/sanitizeError.ts` | Minimal error-message cleaner (Security Plan will expand this later) |
+| Create | `src/utils/sanitizeError.test.ts` | Unit tests for the above |
+| Create | `src/app/EditableTagName.tsx` | Self-contained editable name cell: display mode + edit mode + validation |
+| Create | `src/app/EditableTagName.test.tsx` | Unit tests for EditableTagName |
+| Modify | `src/app/TagTable.tsx` | Add optional `onRename` + `existingNames` props; render `EditableTagName` when present |
+| Create | `src/app/TagManagerApp.rename.test.tsx` | Integration tests for the rename flow end-to-end |
+| Modify | `src/app/TagManagerApp.tsx` | Add `handleRename` callback; pass `onRename` + `existingNames` to `TagTable` |
+
+---
+
+## Task 1 — `validateTagName` utility
+
+**Files:**
+- Create: `src/utils/validateTagName.ts`
+- Create: `src/utils/validateTagName.test.ts`
+
+- [ ] **Step 1.1 — Write the failing tests**
+
+Create `src/utils/validateTagName.test.ts`:
+
+```typescript
+import { validateTagName } from "./validateTagName";
+
+describe("validateTagName", () => {
+  it("accepts a normal tag name", () => {
+    expect(validateTagName("bug")).toEqual({ valid: true });
+  });
+
+  it("rejects an empty string", () => {
+    const result = validateTagName("   ");
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBeTruthy();
+  });
+
+  it("rejects a name longer than 256 characters", () => {
+    const result = validateTagName("a".repeat(257));
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/256/);
+  });
+
+  it("rejects a name that contains a semicolon", () => {
+    const result = validateTagName("bug;feature");
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/semicolon/i);
+  });
+
+  it("accepts a name that is exactly 256 characters", () => {
+    expect(validateTagName("a".repeat(256))).toEqual({ valid: true });
+  });
+
+  it("accepts a name with spaces and hyphens", () => {
+    expect(validateTagName("payment-gateway v2")).toEqual({ valid: true });
+  });
+});
+```
+
+- [ ] **Step 1.2 — Run tests to confirm they fail**
+
+```bash
+cd d:/ado-tag-manager
+pnpm test -- src/utils/validateTagName.test.ts --verbose
+```
+
+Expected: `Cannot find module './validateTagName'`
+
+- [ ] **Step 1.3 — Implement `validateTagName`**
+
+Create `src/utils/validateTagName.ts`:
+
+```typescript
+export interface ValidationResult {
+  valid: boolean;
+  reason?: string;
+}
+
+export function validateTagName(name: string): ValidationResult {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) {
+    return { valid: false, reason: "Tag name cannot be empty." };
+  }
+  if (trimmed.length > 256) {
+    return { valid: false, reason: "Tag name cannot exceed 256 characters." };
+  }
+  if (trimmed.includes(";")) {
+    return {
+      valid: false,
+      reason: 'Tag names cannot contain semicolons — ADO uses ";" to separate tags.',
+    };
+  }
+  return { valid: true };
+}
+```
+
+- [ ] **Step 1.4 — Run tests to confirm they pass**
+
+```bash
+pnpm test -- src/utils/validateTagName.test.ts --verbose
+```
+
+Expected: 6 tests pass.
+
+- [ ] **Step 1.5 — Commit**
+
+```bash
+git add src/utils/validateTagName.ts src/utils/validateTagName.test.ts
+git commit -m "feat: add validateTagName utility"
+```
+
+---
+
+## Task 2 — `sanitizeError` utility
+
+**Files:**
+- Create: `src/utils/sanitizeError.ts`
+- Create: `src/utils/sanitizeError.test.ts`
+
+> **Note:** The Security Hardening plan adds a fuller version of this. If that plan runs first, skip this task — `src/utils/sanitizeError.ts` will already exist.
+
+- [ ] **Step 2.1 — Write the failing tests**
+
+Create `src/utils/sanitizeError.test.ts`:
+
+```typescript
+import { sanitizeError } from "./sanitizeError";
+
+describe("sanitizeError", () => {
+  it("returns the message from an Error", () => {
+    expect(sanitizeError(new Error("something went wrong"))).toBe(
+      "something went wrong"
+    );
+  });
+
+  it("stringifies non-Error values", () => {
+    expect(sanitizeError("raw string")).toBe("raw string");
+    expect(sanitizeError(42)).toBe("42");
+  });
+
+  it("truncates messages longer than 200 characters", () => {
+    const result = sanitizeError(new Error("x".repeat(300)));
+    expect(result.length).toBeLessThanOrEqual(200);
+  });
+
+  it("strips content after the first newline", () => {
+    const result = sanitizeError(new Error("first line\nat: somewhere"));
+    expect(result).toBe("first line");
+  });
+});
+```
+
+- [ ] **Step 2.2 — Run tests to confirm they fail**
+
+```bash
+pnpm test -- src/utils/sanitizeError.test.ts --verbose
+```
+
+Expected: `Cannot find module './sanitizeError'`
+
+- [ ] **Step 2.3 — Implement `sanitizeError`**
+
+Create `src/utils/sanitizeError.ts`:
+
+```typescript
+export function sanitizeError(raw: unknown): string {
+  const msg = raw instanceof Error ? raw.message : String(raw);
+  const firstLine = msg.split("\n")[0];
+  return firstLine.slice(0, 200);
+}
+```
+
+- [ ] **Step 2.4 — Run tests to confirm they pass**
+
+```bash
+pnpm test -- src/utils/sanitizeError.test.ts --verbose
+```
+
+Expected: 4 tests pass.
+
+- [ ] **Step 2.5 — Commit**
+
+```bash
+git add src/utils/sanitizeError.ts src/utils/sanitizeError.test.ts
+git commit -m "feat: add sanitizeError utility"
+```
+
+---
+
+## Task 3 — `EditableTagName`: display mode
+
+**Files:**
+- Create: `src/app/EditableTagName.tsx`
+- Create: `src/app/EditableTagName.test.tsx`
+
+- [ ] **Step 3.1 — Write the failing tests for display mode**
+
+Create `src/app/EditableTagName.test.tsx`:
+
+```typescript
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { EditableTagName } from "./EditableTagName";
+
+const defaultProps = {
+  name: "old-tag",
+  onRename: jest.fn(),
+  onCancel: jest.fn(),
+  existingNames: ["platform", "frontend"],
+};
+
+beforeEach(() => {
+  defaultProps.onRename.mockReset();
+  defaultProps.onCancel.mockReset();
+});
+
+describe("EditableTagName — display mode", () => {
+  it("renders the tag name as text", () => {
+    render(<EditableTagName {...defaultProps} />);
+    expect(screen.getByText("old-tag")).toBeInTheDocument();
+  });
+
+  it("does not show an input initially", () => {
+    render(<EditableTagName {...defaultProps} />);
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("shows a pencil icon when hovered", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.hover(screen.getByText("old-tag"));
+    expect(screen.getByTitle("Rename")).toBeInTheDocument();
+  });
+
+  it("hides the pencil icon when not hovered", () => {
+    render(<EditableTagName {...defaultProps} />);
+    expect(screen.queryByTitle("Rename")).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3.2 — Run tests to confirm they fail**
+
+```bash
+pnpm test -- src/app/EditableTagName.test.tsx --verbose
+```
+
+Expected: `Cannot find module './EditableTagName'`
+
+- [ ] **Step 3.3 — Implement display mode only**
+
+Create `src/app/EditableTagName.tsx`:
+
+```typescript
+import React, { useState } from "react";
+import { validateTagName } from "../utils/validateTagName";
+
+export interface EditableTagNameProps {
+  name: string;
+  onRename: (newName: string) => void;
+  onCancel: () => void;
+  existingNames: string[];
+}
+
+export const EditableTagName: React.FC<EditableTagNameProps> = ({
+  name,
+  onRename,
+  onCancel,
+  existingNames,
+}) => {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(name);
+  const [error, setError] = useState<string | null>(null);
+  const [hovered, setHovered] = useState(false);
+
+  if (editing) {
+    // Placeholder — edit mode implemented in Task 4
+    return <span>{name}</span>;
+  }
+
+  return (
+    <span
+      onDoubleClick={() => {
+        setDraft(name);
+        setError(null);
+        setEditing(true);
+      }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{ display: "inline-flex", alignItems: "center", gap: "6px", cursor: "default" }}
+    >
+      {name}
+      {hovered && (
+        <span
+          aria-hidden="true"
+          title="Rename"
+          style={{ fontSize: "11px", color: "var(--palette-neutral-30, #aaa)" }}
+        >
+          ✎
+        </span>
+      )}
+    </span>
+  );
+};
+```
+
+- [ ] **Step 3.4 — Run display-mode tests to confirm they pass**
+
+```bash
+pnpm test -- src/app/EditableTagName.test.tsx --verbose
+```
+
+Expected: 4 display-mode tests pass.
+
+- [ ] **Step 3.5 — Commit**
+
+```bash
+git add src/app/EditableTagName.tsx src/app/EditableTagName.test.tsx
+git commit -m "feat: add EditableTagName display mode with hover pencil"
+```
+
+---
+
+## Task 4 — `EditableTagName`: edit mode, commit, cancel
+
+**Files:**
+- Modify: `src/app/EditableTagName.test.tsx`
+- Modify: `src/app/EditableTagName.tsx`
+
+- [ ] **Step 4.1 — Add failing tests for edit mode**
+
+Append to the `describe` blocks in `src/app/EditableTagName.test.tsx`:
+
+```typescript
+describe("EditableTagName — entering edit mode", () => {
+  it("shows a text input after double-click", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.dblClick(screen.getByText("old-tag"));
+    expect(screen.getByRole("textbox", { name: "Edit tag name" })).toBeInTheDocument();
+  });
+
+  it("pre-fills the input with the current name", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.dblClick(screen.getByText("old-tag"));
+    expect(screen.getByRole("textbox", { name: "Edit tag name" })).toHaveValue("old-tag");
+  });
+});
+
+describe("EditableTagName — committing a rename", () => {
+  it("calls onRename with the trimmed new value when Enter is pressed", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.dblClick(screen.getByText("old-tag"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "new-name");
+    await user.keyboard("[Enter]");
+    expect(defaultProps.onRename).toHaveBeenCalledWith("new-name");
+  });
+
+  it("exits edit mode after Enter", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.dblClick(screen.getByText("old-tag"));
+    await user.keyboard("[Enter]");
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("calls onRename when the input is blurred", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.dblClick(screen.getByText("old-tag"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "blurred-name");
+    await user.tab();
+    expect(defaultProps.onRename).toHaveBeenCalledWith("blurred-name");
+  });
+});
+
+describe("EditableTagName — cancelling a rename", () => {
+  it("calls onCancel and exits edit mode when Escape is pressed", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.dblClick(screen.getByText("old-tag"));
+    await user.keyboard("[Escape]");
+    expect(defaultProps.onCancel).toHaveBeenCalled();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("shows the original name again after Escape", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.dblClick(screen.getByText("old-tag"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "something-else");
+    await user.keyboard("[Escape]");
+    expect(screen.getByText("old-tag")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 4.2 — Run new tests to confirm they fail**
+
+```bash
+pnpm test -- src/app/EditableTagName.test.tsx --verbose
+```
+
+Expected: The new edit-mode, commit, and cancel tests fail; display-mode tests still pass.
+
+- [ ] **Step 4.3 — Implement edit mode, commit, and cancel**
+
+Replace the full `src/app/EditableTagName.tsx` with:
+
+```typescript
+import React, { useRef, useState } from "react";
+import { validateTagName } from "../utils/validateTagName";
+
+export interface EditableTagNameProps {
+  name: string;
+  onRename: (newName: string) => void;
+  onCancel: () => void;
+  existingNames: string[];
+}
+
+export const EditableTagName: React.FC<EditableTagNameProps> = ({
+  name,
+  onRename,
+  onCancel,
+  existingNames,
+}) => {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(name);
+  const [error, setError] = useState<string | null>(null);
+  const [hovered, setHovered] = useState(false);
+  // Prevents blur from triggering a second commit after Enter already committed.
+  const committedRef = useRef(false);
+
+  const commit = () => {
+    if (committedRef.current) return;
+    const validation = validateTagName(draft);
+    if (!validation.valid) {
+      setError(validation.reason ?? "Invalid tag name.");
+      return;
+    }
+    const isDuplicate =
+      draft.trim().toLowerCase() !== name.toLowerCase() &&
+      existingNames.some((n) => n.toLowerCase() === draft.trim().toLowerCase());
+    if (isDuplicate) {
+      setError("A tag with this name already exists — use Merge instead.");
+      return;
+    }
+    committedRef.current = true;
+    setEditing(false);
+    setError(null);
+    onRename(draft.trim());
+    // Reset after microtask so blur fired in the same tick is swallowed.
+    Promise.resolve().then(() => {
+      committedRef.current = false;
+    });
+  };
+
+  const cancel = () => {
+    committedRef.current = true;
+    setEditing(false);
+    setDraft(name);
+    setError(null);
+    onCancel();
+    Promise.resolve().then(() => {
+      committedRef.current = false;
+    });
+  };
+
+  if (editing) {
+    return (
+      <div>
+        <input
+          aria-label="Edit tag name"
+          autoFocus
+          value={draft}
+          onChange={(e) => {
+            setDraft(e.target.value);
+            setError(null);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              commit();
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              cancel();
+            }
+          }}
+          onBlur={commit}
+          style={{
+            width: "100%",
+            boxSizing: "border-box",
+            padding: "2px 6px",
+            fontSize: "13px",
+            border: "1px solid var(--palette-neutral-20, #c8c6c4)",
+            borderRadius: "2px",
+            background: "var(--callout-background-color, #fff)",
+            color: "var(--text-primary-color, #1e1e1e)",
+            outline: "none",
+          }}
+        />
+        {error && (
+          <div
+            role="alert"
+            style={{
+              fontSize: "12px",
+              color: "var(--status-error-foreground, #c4314b)",
+              marginTop: "2px",
+            }}
+          >
+            {error}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <span
+      onDoubleClick={() => {
+        setDraft(name);
+        setError(null);
+        setEditing(true);
+      }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{ display: "inline-flex", alignItems: "center", gap: "6px", cursor: "default" }}
+    >
+      {name}
+      {hovered && (
+        <span
+          aria-hidden="true"
+          title="Rename"
+          style={{ fontSize: "11px", color: "var(--palette-neutral-30, #aaa)" }}
+        >
+          ✎
+        </span>
+      )}
+    </span>
+  );
+};
+```
+
+- [ ] **Step 4.4 — Run all EditableTagName tests to confirm they pass**
+
+```bash
+pnpm test -- src/app/EditableTagName.test.tsx --verbose
+```
+
+Expected: All tests pass (display mode + edit mode + commit + cancel).
+
+- [ ] **Step 4.5 — Commit**
+
+```bash
+git add src/app/EditableTagName.tsx src/app/EditableTagName.test.tsx
+git commit -m "feat: add EditableTagName edit mode with commit and cancel"
+```
+
+---
+
+## Task 5 — `EditableTagName`: validation error states
+
+**Files:**
+- Modify: `src/app/EditableTagName.test.tsx`
+
+- [ ] **Step 5.1 — Add failing tests for validation**
+
+Append to `src/app/EditableTagName.test.tsx`:
+
+```typescript
+describe("EditableTagName — validation", () => {
+  it("shows an error and stays in edit mode when Enter is pressed with empty input", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.dblClick(screen.getByText("old-tag"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.keyboard("[Enter]");
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(defaultProps.onRename).not.toHaveBeenCalled();
+  });
+
+  it("shows a merge hint when the typed name matches an existing tag", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.dblClick(screen.getByText("old-tag"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "platform");
+    await user.keyboard("[Enter]");
+    expect(screen.getByRole("alert")).toHaveTextContent(/Merge/i);
+    expect(defaultProps.onRename).not.toHaveBeenCalled();
+  });
+
+  it("treats duplicate check as case-insensitive", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.dblClick(screen.getByText("old-tag"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "PLATFORM");
+    await user.keyboard("[Enter]");
+    expect(screen.getByRole("alert")).toHaveTextContent(/Merge/i);
+  });
+
+  it("allows renaming to the same name (no-op rename, not a duplicate)", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.dblClick(screen.getByText("old-tag"));
+    await user.keyboard("[Enter]");
+    expect(defaultProps.onRename).toHaveBeenCalledWith("old-tag");
+  });
+
+  it("clears the error message when the user starts typing again", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.dblClick(screen.getByText("old-tag"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.keyboard("[Enter]");
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    await user.type(input, "f");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 5.2 — Run new tests to confirm they fail**
+
+```bash
+pnpm test -- src/app/EditableTagName.test.tsx --verbose
+```
+
+Expected: The 5 new validation tests fail; earlier tests still pass.
+
+- [ ] **Step 5.3 — Run all tests to confirm they pass (validation logic already in place from Task 4)**
+
+The validation logic was already added in Task 4's implementation (`commit()` function checks `validateTagName` and `isDuplicate`). Run the full file to verify:
+
+```bash
+pnpm test -- src/app/EditableTagName.test.tsx --verbose
+```
+
+Expected: All tests pass. If any fail, review the `commit()` function in `EditableTagName.tsx` against the logic in Task 4 step 4.3.
+
+- [ ] **Step 5.4 — Commit**
+
+```bash
+git add src/app/EditableTagName.test.tsx
+git commit -m "test: add validation tests for EditableTagName"
+```
+
+---
+
+## Task 6 — Wire `EditableTagName` into `TagTable`
+
+**Files:**
+- Modify: `src/app/TagTable.tsx`
+- Modify: `src/app/TagTable.test.tsx`
+
+- [ ] **Step 6.1 — Add failing tests for the wired TagTable**
+
+Append to `src/app/TagTable.test.tsx`:
+
+```typescript
+describe("TagTable — rename wiring", () => {
+  it("renders EditableTagName when onRename is provided", async () => {
+    const user = userEvent.setup();
+    const onRename = jest.fn();
+    render(
+      <TagTable
+        tags={[{ id: "1", name: "alpha", url: "u1" }]}
+        selectedIds={new Set()}
+        onToggle={jest.fn()}
+        onToggleAll={jest.fn()}
+        onRename={onRename}
+        existingNames={["alpha"]}
+      />
+    );
+    await user.dblClick(screen.getByText("alpha"));
+    expect(screen.getByRole("textbox", { name: "Edit tag name" })).toBeInTheDocument();
+  });
+
+  it("renders plain text when onRename is not provided", () => {
+    render(
+      <TagTable
+        tags={[{ id: "1", name: "alpha", url: "u1" }]}
+        selectedIds={new Set()}
+        onToggle={jest.fn()}
+        onToggleAll={jest.fn()}
+      />
+    );
+    expect(screen.getByText("alpha")).toBeInTheDocument();
+    expect(screen.queryByTitle("Rename")).not.toBeInTheDocument();
+  });
+
+  it("calls onRename with tagId and new name when rename is committed", async () => {
+    const user = userEvent.setup();
+    const onRename = jest.fn();
+    render(
+      <TagTable
+        tags={[{ id: "tag-1", name: "alpha", url: "u1" }]}
+        selectedIds={new Set()}
+        onToggle={jest.fn()}
+        onToggleAll={jest.fn()}
+        onRename={onRename}
+        existingNames={["alpha"]}
+      />
+    );
+    await user.dblClick(screen.getByText("alpha"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "beta");
+    await user.keyboard("[Enter]");
+    expect(onRename).toHaveBeenCalledWith("tag-1", "beta");
+  });
+});
+```
+
+- [ ] **Step 6.2 — Run new tests to confirm they fail**
+
+```bash
+pnpm test -- src/app/TagTable.test.tsx --verbose
+```
+
+Expected: The 3 new rename-wiring tests fail; original 2 tests pass.
+
+- [ ] **Step 6.3 — Modify `TagTable` to accept and wire the new props**
+
+Replace the full `src/app/TagTable.tsx` with:
+
+```typescript
+// src/app/TagTable.tsx
+import React, { useMemo } from "react";
+import {
+  ColumnFillId,
+  ITableColumn,
+  SimpleTableCell,
+  Table,
+} from "azure-devops-ui/Table";
+import { ObservableValue } from "azure-devops-ui/Core/Observable";
+import { ArrayItemProvider } from "azure-devops-ui/Utilities/Provider";
+import { Checkbox } from "azure-devops-ui/Checkbox";
+import { ZeroData } from "azure-devops-ui/ZeroData";
+import { Spinner, SpinnerSize } from "azure-devops-ui/Spinner";
+import { TagItem } from "../types";
+import { EditableTagName } from "./EditableTagName";
+
+interface TagTableProps {
+  tags: TagItem[];
+  selectedIds: Set<string>;
+  onToggle: (id: string) => void;
+  onToggleAll: (select: boolean) => void;
+  onRename?: (tagId: string, newName: string) => void;
+  existingNames?: string[];
+}
+
+// Column widths are stable ObservableValues — defined outside the component
+// so they are not recreated on every render (prevents ADO Table column flicker).
+const colWidthSelect = new ObservableValue(48);
+const colWidthName = new ObservableValue(300);
+
+export const TagTable: React.FC<TagTableProps> = ({
+  tags,
+  selectedIds,
+  onToggle,
+  onToggleAll,
+  onRename,
+  existingNames = [],
+}) => {
+  if (tags.length === 0) {
+    return (
+      <ZeroData
+        primaryText="No tags found"
+        secondaryText="This project has no work item tags yet."
+        imageAltText=""
+      />
+    );
+  }
+
+  const allSelected = tags.length > 0 && tags.every((t) => selectedIds.has(t.id));
+  const someSelected = tags.some((t) => selectedIds.has(t.id));
+
+  const tableItems = new ArrayItemProvider<TagItem>(tags);
+
+  // Column renderers that close over selectedIds/onToggle are memoized so the
+  // Table does not reinitialize on every checkbox toggle.
+  const columns: ITableColumn<TagItem>[] = useMemo(() => [
+    {
+      id: "select",
+      name: "",
+      renderCell: (_rowIndex, columnIndex, tableColumn, item) => (
+        <SimpleTableCell
+          columnIndex={columnIndex}
+          tableColumn={tableColumn}
+          key={`sel-${item.id}`}
+        >
+          <Checkbox
+            checked={selectedIds.has(item.id)}
+            onChange={(_e, _checked) => onToggle(item.id)}
+          />
+        </SimpleTableCell>
+      ),
+      renderHeaderCell: (columnIndex, tableColumn) => (
+        <SimpleTableCell
+          columnIndex={columnIndex}
+          tableColumn={tableColumn}
+          key="sel-header"
+        >
+          <Checkbox
+            triState={true}
+            checked={someSelected && !allSelected ? undefined : allSelected}
+            onChange={(_e, checked) => onToggleAll(checked ?? false)}
+          />
+        </SimpleTableCell>
+      ),
+      readonly: true,
+      width: colWidthSelect,
+    },
+    {
+      id: "name",
+      name: "Tag",
+      renderCell: (_rowIndex, columnIndex, tableColumn, item) => (
+        <SimpleTableCell
+          columnIndex={columnIndex}
+          tableColumn={tableColumn}
+          key={`name-${item.id}`}
+        >
+          {onRename ? (
+            <EditableTagName
+              name={item.name}
+              onRename={(newName) => onRename(item.id, newName)}
+              onCancel={() => {}}
+              existingNames={existingNames}
+            />
+          ) : (
+            item.name
+          )}
+        </SimpleTableCell>
+      ),
+      readonly: true,
+      width: colWidthName,
+    },
+    {
+      id: ColumnFillId,
+      name: "Work Items",
+      renderCell: (_rowIndex, columnIndex, tableColumn, item) => (
+        <SimpleTableCell
+          columnIndex={columnIndex}
+          tableColumn={tableColumn}
+          key={`count-${item.id}`}
+        >
+          {item.count === undefined ? (
+            <span style={{ color: "var(--palette-neutral-30, #aaa)" }}>—</span>
+          ) : item.count === -1 ? (
+            <Spinner size={SpinnerSize.small} />
+          ) : (
+            String(item.count)
+          )}
+        </SimpleTableCell>
+      ),
+      readonly: true,
+      width: -1,
+    },
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  ], [selectedIds, onToggle, onToggleAll, allSelected, someSelected, onRename, existingNames]);
+
+  return (
+    <Table<TagItem>
+      ariaLabel="Work item tags"
+      columns={columns}
+      itemProvider={tableItems}
+      role="grid"
+    />
+  );
+};
+```
+
+- [ ] **Step 6.4 — Run all TagTable tests to confirm they pass**
+
+```bash
+pnpm test -- src/app/TagTable.test.tsx --verbose
+```
+
+Expected: All 5 tests pass.
+
+- [ ] **Step 6.5 — Run the full suite to confirm no regressions**
+
+```bash
+pnpm test
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 6.6 — Commit**
+
+```bash
+git add src/app/TagTable.tsx src/app/TagTable.test.tsx
+git commit -m "feat: wire EditableTagName into TagTable name column"
+```
+
+---
+
+## Task 7 — `TagManagerApp`: `handleRename` + integration tests (success path)
+
+**Files:**
+- Create: `src/app/TagManagerApp.rename.test.tsx`
+- Modify: `src/app/TagManagerApp.tsx`
+
+- [ ] **Step 7.1 — Write the failing integration tests**
+
+Create `src/app/TagManagerApp.rename.test.tsx`:
+
+```typescript
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockTagService = {
+  getAllTags: jest.fn(),
+  getProjectName: jest.fn(),
+  deleteTagById: jest.fn(),
+  renameTagById: jest.fn(),
+  mergeTag: jest.fn(),
+  countTagAcrossProjects: jest.fn(),
+};
+
+jest.mock("../services/TagService", () => ({
+  TagService: jest.fn(() => mockTagService),
+}));
+
+import { TagManagerApp } from "./TagManagerApp";
+
+beforeEach(() => {
+  localStorage.clear();
+  Object.values(mockTagService).forEach((fn) => (fn as jest.Mock).mockReset());
+  mockTagService.getProjectName.mockResolvedValue("Demo Project");
+  mockTagService.getAllTags.mockResolvedValue([
+    { id: "1", name: "alpha", url: "u" },
+    { id: "2", name: "beta", url: "u" },
+  ]);
+  mockTagService.renameTagById.mockResolvedValue({ id: "1", name: "renamed-tag", url: "u" });
+});
+
+describe("TagManagerApp — rename flow", () => {
+  it("calls renameTagById with the correct id and new name", async () => {
+    const user = userEvent.setup();
+    render(<TagManagerApp />);
+
+    await waitFor(() => expect(screen.getByText("alpha")).toBeInTheDocument());
+
+    await user.dblClick(screen.getByText("alpha"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "renamed-tag");
+    await user.keyboard("[Enter]");
+
+    await waitFor(() => {
+      expect(mockTagService.renameTagById).toHaveBeenCalledWith("1", "renamed-tag");
+    });
+  });
+
+  it("updates the tag name in the list after a successful rename", async () => {
+    const user = userEvent.setup();
+    render(<TagManagerApp />);
+
+    await waitFor(() => expect(screen.getByText("alpha")).toBeInTheDocument());
+
+    await user.dblClick(screen.getByText("alpha"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "renamed-tag");
+    await user.keyboard("[Enter]");
+
+    await waitFor(() => {
+      expect(screen.getByText("renamed-tag")).toBeInTheDocument();
+      expect(screen.queryByText("alpha")).not.toBeInTheDocument();
+    });
+  });
+
+  it("appends a success entry to the activity log after rename", async () => {
+    const user = userEvent.setup();
+    render(<TagManagerApp />);
+
+    await waitFor(() => expect(screen.getByText("alpha")).toBeInTheDocument());
+
+    await user.dblClick(screen.getByText("alpha"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "renamed-tag");
+    await user.keyboard("[Enter]");
+
+    await waitFor(() => {
+      expect(screen.getByText(/Activity Log/)).toBeInTheDocument();
+    });
+
+    // Open the log
+    const user2 = userEvent.setup();
+    await user2.click(screen.getByText(/Activity Log/));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/✓ Renamed "alpha" → "renamed-tag"/)
+      ).toBeInTheDocument();
+    });
+  });
+});
+```
+
+- [ ] **Step 7.2 — Run tests to confirm they fail**
+
+```bash
+pnpm test -- src/app/TagManagerApp.rename.test.tsx --verbose
+```
+
+Expected: Tests fail because `TagManagerApp` does not yet pass `onRename` to `TagTable` and has no `handleRename`.
+
+- [ ] **Step 7.3 — Add `handleRename` and wire it to `TagTable` in `TagManagerApp.tsx`**
+
+Open `src/app/TagManagerApp.tsx`. Make the following changes:
+
+**a) Add import for `sanitizeError` at the top of the file (after the existing imports):**
+
+```typescript
+import { sanitizeError } from "../utils/sanitizeError";
+```
+
+**b) Add `handleRename` callback after the `updateTagCount` definition (around line 88):**
+
+```typescript
+const handleRename = useCallback(async (tagId: string, newName: string) => {
+  const original = tags.find((t) => t.id === tagId)?.name ?? tagId;
+  const logId = appendLog(`${proj}Renaming "${original}" → "${newName}"…`, "running");
+  try {
+    const updated = await tagService.renameTagById(tagId, newName);
+    setTags((prev) =>
+      prev.map((t) => (t.id === tagId ? { ...t, name: updated.name } : t))
+    );
+    updateLog(logId, `${proj}✓ Renamed "${original}" → "${updated.name}"`, "success");
+  } catch (e) {
+    updateLog(logId, `${proj}✗ Failed to rename "${original}": ${sanitizeError(e)}`, "error");
+  }
+}, [tags, proj, appendLog, updateLog]);
+```
+
+**c) In the JSX, update the `<TagTable>` call** (around line 303) to pass the new props:
+
+```typescript
+<TagTable
+  tags={pagedTags}
+  selectedIds={selectedIds}
+  onToggle={handleToggle}
+  onToggleAll={handleToggleAll}
+  onRename={handleRename}
+  existingNames={tags.map((t) => t.name)}
+/>
+```
+
+> **Note on `proj` dependency:** `proj` is derived inline (`const proj = projectName ? ...`). Move the `proj` declaration above `handleRename` so it is in scope. It already exists in the file; just ensure `handleRename` is placed after `proj` is declared.
+
+- [ ] **Step 7.4 — Run the integration tests to confirm they pass**
+
+```bash
+pnpm test -- src/app/TagManagerApp.rename.test.tsx --verbose
+```
+
+Expected: All 3 tests pass.
+
+- [ ] **Step 7.5 — Run the full suite to confirm no regressions**
+
+```bash
+pnpm test
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 7.6 — Commit**
+
+```bash
+git add src/app/TagManagerApp.tsx src/app/TagManagerApp.rename.test.tsx
+git commit -m "feat: add handleRename to TagManagerApp and wire to TagTable"
+```
+
+---
+
+## Task 8 — API failure path
+
+**Files:**
+- Modify: `src/app/TagManagerApp.rename.test.tsx`
+
+- [ ] **Step 8.1 — Add failing tests for the error path**
+
+Append to `src/app/TagManagerApp.rename.test.tsx`:
+
+```typescript
+describe("TagManagerApp — rename failure", () => {
+  it("appends an error log entry when renameTagById throws", async () => {
+    mockTagService.renameTagById.mockRejectedValue(new Error("permission denied"));
+    const user = userEvent.setup();
+    render(<TagManagerApp />);
+
+    await waitFor(() => expect(screen.getByText("alpha")).toBeInTheDocument());
+
+    await user.dblClick(screen.getByText("alpha"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "new-name");
+    await user.keyboard("[Enter]");
+
+    // Open the log
+    await waitFor(() => screen.getByText(/Activity Log/));
+    const user2 = userEvent.setup();
+    await user2.click(screen.getByText(/Activity Log/));
+
+    await waitFor(() => {
+      expect(screen.getByText(/✗ Failed to rename "alpha"/)).toBeInTheDocument();
+      expect(screen.getByText(/permission denied/)).toBeInTheDocument();
+    });
+  });
+
+  it("leaves the original tag name in the list when rename fails", async () => {
+    mockTagService.renameTagById.mockRejectedValue(new Error("permission denied"));
+    const user = userEvent.setup();
+    render(<TagManagerApp />);
+
+    await waitFor(() => expect(screen.getByText("alpha")).toBeInTheDocument());
+
+    await user.dblClick(screen.getByText("alpha"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "new-name");
+    await user.keyboard("[Enter]");
+
+    await waitFor(() => {
+      expect(mockTagService.renameTagById).toHaveBeenCalled();
+    });
+
+    // Tag name in state is unchanged because setTags only runs on success
+    expect(screen.getByText("alpha")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 8.2 — Run new tests to confirm they pass**
+
+```bash
+pnpm test -- src/app/TagManagerApp.rename.test.tsx --verbose
+```
+
+Expected: All 5 tests pass (3 success + 2 failure).
+
+- [ ] **Step 8.3 — Run the full suite one final time**
+
+```bash
+pnpm test
+```
+
+Expected: All tests pass with no regressions.
+
+- [ ] **Step 8.4 — Commit**
+
+```bash
+git add src/app/TagManagerApp.rename.test.tsx
+git commit -m "test: add rename failure path tests for TagManagerApp"
+```
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- [x] Double-click triggers edit mode → Task 4
+- [x] Input pre-filled with current name → Task 4
+- [x] Enter commits → Task 4
+- [x] Blur commits → Task 4
+- [x] Escape cancels → Task 4
+- [x] Pencil icon on hover → Task 3
+- [x] `validateTagName` on commit → Task 5
+- [x] Duplicate detection (case-insensitive) → Task 5
+- [x] Duplicate message "use Merge instead" → Task 5
+- [x] `EditableTagName` in `TagTable` name column → Task 6
+- [x] Falls back to plain text when `onRename` absent → Task 6
+- [x] `handleRename` in `TagManagerApp` → Task 7
+- [x] Success: `setTags` updates name in list → Task 7
+- [x] Success: activity log entry → Task 7
+- [x] Failure: log entry with error message → Task 8
+- [x] Failure: tag name unchanged in list → Task 8
+- [x] `sanitizeError` in error log message → Task 7 (via `sanitizeError` import)
+
+**Cross-plan dependency note:** If the Security Hardening plan (Plan 1) is implemented after this plan, `src/utils/sanitizeError.ts` will already exist. The Security plan should extend the existing file rather than overwrite it.

--- a/src/app/EditableTagName.test.tsx
+++ b/src/app/EditableTagName.test.tsx
@@ -37,6 +37,15 @@ describe("EditableTagName — display mode", () => {
     render(<EditableTagName {...defaultProps} />);
     expect(screen.queryByTitle("Rename")).not.toBeInTheDocument();
   });
+
+  it("shows a visible focus outline when focused", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.tab();
+    expect(screen.getByRole("button", { name: /Rename tag old-tag/i })).toHaveStyle(
+      "outline: 2px solid var(--communication-foreground, #0078d4)"
+    );
+  });
 });
 
 describe("EditableTagName — entering edit mode", () => {
@@ -67,6 +76,14 @@ describe("EditableTagName — entering edit mode", () => {
     render(<EditableTagName {...defaultProps} />);
     await user.tab();
     await user.keyboard("{F2}");
+    expect(screen.getByRole("textbox", { name: "Edit tag name" })).toBeInTheDocument();
+  });
+
+  it("enters edit mode with keyboard Space when focused", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.tab();
+    await user.keyboard(" ");
     expect(screen.getByRole("textbox", { name: "Edit tag name" })).toBeInTheDocument();
   });
 });

--- a/src/app/EditableTagName.test.tsx
+++ b/src/app/EditableTagName.test.tsx
@@ -118,6 +118,35 @@ describe("EditableTagName — committing a rename", () => {
     await user.tab();
     expect(defaultProps.onRename).toHaveBeenCalledWith("blurred-name");
   });
+
+  it("disables re-entry while rename is in flight", async () => {
+    let resolveRename: (() => void) | undefined;
+    const onRename = jest.fn(
+      () => new Promise<void>((resolve) => { resolveRename = resolve; })
+    );
+    const user = userEvent.setup();
+    render(
+      <EditableTagName
+        name="old-tag"
+        onRename={onRename}
+        onCancel={jest.fn()}
+        existingNames={[]}
+      />
+    );
+
+    await user.dblClick(screen.getByText("old-tag"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "new-name");
+    await user.keyboard("[Enter]");
+
+    const trigger = screen.getByRole("button", { name: /Rename tag old-tag/i });
+    await user.dblClick(trigger);
+    expect(screen.queryByRole("textbox", { name: "Edit tag name" })).not.toBeInTheDocument();
+
+    resolveRename?.();
+    await waitFor(() => expect(onRename).toHaveBeenCalledTimes(1));
+  });
 });
 
 describe("EditableTagName — cancelling a rename", () => {

--- a/src/app/EditableTagName.test.tsx
+++ b/src/app/EditableTagName.test.tsx
@@ -53,6 +53,22 @@ describe("EditableTagName — entering edit mode", () => {
     await user.dblClick(screen.getByText("old-tag"));
     expect(screen.getByRole("textbox", { name: "Edit tag name" })).toHaveValue("old-tag");
   });
+
+  it("enters edit mode with keyboard Enter when focused", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.tab();
+    await user.keyboard("[Enter]");
+    expect(screen.getByRole("textbox", { name: "Edit tag name" })).toBeInTheDocument();
+  });
+
+  it("enters edit mode with keyboard F2 when focused", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.tab();
+    await user.keyboard("{F2}");
+    expect(screen.getByRole("textbox", { name: "Edit tag name" })).toBeInTheDocument();
+  });
 });
 
 describe("EditableTagName — committing a rename", () => {

--- a/src/app/EditableTagName.test.tsx
+++ b/src/app/EditableTagName.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { EditableTagName } from "./EditableTagName";
 
@@ -106,6 +106,28 @@ describe("EditableTagName — cancelling a rename", () => {
     await user.type(input, "something-else");
     await user.keyboard("[Escape]");
     expect(screen.getByText("old-tag")).toBeInTheDocument();
+  });
+
+  it("calls onCancel when onRename rejects (API failure)", async () => {
+    const onRename = jest.fn().mockRejectedValue(new Error("api error"));
+    const onCancel = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <EditableTagName
+        name="old-tag"
+        onRename={onRename}
+        onCancel={onCancel}
+        existingNames={[]}
+      />
+    );
+    await user.dblClick(screen.getByText("old-tag"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "new-name");
+    await user.keyboard("[Enter]");
+    await waitFor(() => {
+      expect(onCancel).toHaveBeenCalled();
+    });
   });
 });
 

--- a/src/app/EditableTagName.test.tsx
+++ b/src/app/EditableTagName.test.tsx
@@ -1,0 +1,167 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { EditableTagName } from "./EditableTagName";
+
+const defaultProps = {
+  name: "old-tag",
+  onRename: jest.fn(),
+  onCancel: jest.fn(),
+  existingNames: ["platform", "frontend"],
+};
+
+beforeEach(() => {
+  defaultProps.onRename.mockReset();
+  defaultProps.onCancel.mockReset();
+});
+
+describe("EditableTagName — display mode", () => {
+  it("renders the tag name as text", () => {
+    render(<EditableTagName {...defaultProps} />);
+    expect(screen.getByText("old-tag")).toBeInTheDocument();
+  });
+
+  it("does not show an input initially", () => {
+    render(<EditableTagName {...defaultProps} />);
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("shows a pencil icon when hovered", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.hover(screen.getByText("old-tag"));
+    expect(screen.getByTitle("Rename")).toBeInTheDocument();
+  });
+
+  it("hides the pencil icon when not hovered", () => {
+    render(<EditableTagName {...defaultProps} />);
+    expect(screen.queryByTitle("Rename")).not.toBeInTheDocument();
+  });
+});
+
+describe("EditableTagName — entering edit mode", () => {
+  it("shows a text input after double-click", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.dblClick(screen.getByText("old-tag"));
+    expect(screen.getByRole("textbox", { name: "Edit tag name" })).toBeInTheDocument();
+  });
+
+  it("pre-fills the input with the current name", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.dblClick(screen.getByText("old-tag"));
+    expect(screen.getByRole("textbox", { name: "Edit tag name" })).toHaveValue("old-tag");
+  });
+});
+
+describe("EditableTagName — committing a rename", () => {
+  it("calls onRename with the trimmed new value when Enter is pressed", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.dblClick(screen.getByText("old-tag"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "new-name");
+    await user.keyboard("[Enter]");
+    expect(defaultProps.onRename).toHaveBeenCalledWith("new-name");
+  });
+
+  it("exits edit mode after Enter", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.dblClick(screen.getByText("old-tag"));
+    await user.keyboard("[Enter]");
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("calls onRename when the input is blurred", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.dblClick(screen.getByText("old-tag"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "blurred-name");
+    await user.tab();
+    expect(defaultProps.onRename).toHaveBeenCalledWith("blurred-name");
+  });
+});
+
+describe("EditableTagName — cancelling a rename", () => {
+  it("calls onCancel and exits edit mode when Escape is pressed", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.dblClick(screen.getByText("old-tag"));
+    await user.keyboard("[Escape]");
+    expect(defaultProps.onCancel).toHaveBeenCalled();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("shows the original name again after Escape", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.dblClick(screen.getByText("old-tag"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "something-else");
+    await user.keyboard("[Escape]");
+    expect(screen.getByText("old-tag")).toBeInTheDocument();
+  });
+});
+
+describe("EditableTagName — validation", () => {
+  it("shows an error and stays in edit mode when Enter is pressed with empty input", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.dblClick(screen.getByText("old-tag"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.keyboard("[Enter]");
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(defaultProps.onRename).not.toHaveBeenCalled();
+  });
+
+  it("shows a merge hint when the typed name matches an existing tag", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.dblClick(screen.getByText("old-tag"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "platform");
+    await user.keyboard("[Enter]");
+    expect(screen.getByRole("alert")).toHaveTextContent(/Merge/i);
+    expect(defaultProps.onRename).not.toHaveBeenCalled();
+  });
+
+  it("treats duplicate check as case-insensitive", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.dblClick(screen.getByText("old-tag"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "PLATFORM");
+    await user.keyboard("[Enter]");
+    expect(screen.getByRole("alert")).toHaveTextContent(/Merge/i);
+  });
+
+  it("allows renaming to the same name (no-op rename, not a duplicate)", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.dblClick(screen.getByText("old-tag"));
+    await user.keyboard("[Enter]");
+    expect(defaultProps.onRename).toHaveBeenCalledWith("old-tag");
+  });
+
+  it("clears the error message when the user starts typing again", async () => {
+    const user = userEvent.setup();
+    render(<EditableTagName {...defaultProps} />);
+    await user.dblClick(screen.getByText("old-tag"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.keyboard("[Enter]");
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    await user.type(input, "f");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/src/app/EditableTagName.tsx
+++ b/src/app/EditableTagName.tsx
@@ -1,0 +1,131 @@
+import React, { useRef, useState } from "react";
+import { validateTagName } from "../utils/validateTagName";
+
+export interface EditableTagNameProps {
+  name: string;
+  onRename: (newName: string) => void;
+  onCancel: () => void;
+  existingNames: string[];
+}
+
+export const EditableTagName: React.FC<EditableTagNameProps> = ({
+  name,
+  onRename,
+  onCancel,
+  existingNames,
+}) => {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(name);
+  const [error, setError] = useState<string | null>(null);
+  const [hovered, setHovered] = useState(false);
+  // Prevents blur from triggering a second commit after Enter already committed.
+  const committedRef = useRef(false);
+
+  const commit = () => {
+    if (committedRef.current) return;
+    const validation = validateTagName(draft);
+    if (!validation.valid) {
+      setError(validation.reason ?? "Invalid tag name.");
+      return;
+    }
+    const isDuplicate =
+      draft.trim().toLowerCase() !== name.toLowerCase() &&
+      existingNames.some((n) => n.toLowerCase() === draft.trim().toLowerCase());
+    if (isDuplicate) {
+      setError("A tag with this name already exists — use Merge instead.");
+      return;
+    }
+    committedRef.current = true;
+    setEditing(false);
+    setError(null);
+    onRename(draft.trim());
+    // Reset after microtask so blur fired in the same tick is swallowed.
+    Promise.resolve().then(() => {
+      committedRef.current = false;
+    });
+  };
+
+  const cancel = () => {
+    committedRef.current = true;
+    setEditing(false);
+    setDraft(name);
+    setError(null);
+    onCancel();
+    Promise.resolve().then(() => {
+      committedRef.current = false;
+    });
+  };
+
+  if (editing) {
+    return (
+      <div>
+        <input
+          aria-label="Edit tag name"
+          autoFocus
+          value={draft}
+          onChange={(e) => {
+            setDraft(e.target.value);
+            setError(null);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              commit();
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              cancel();
+            }
+          }}
+          onBlur={commit}
+          style={{
+            width: "100%",
+            boxSizing: "border-box",
+            padding: "2px 6px",
+            fontSize: "13px",
+            border: "1px solid var(--palette-neutral-20, #c8c6c4)",
+            borderRadius: "2px",
+            background: "var(--callout-background-color, #fff)",
+            color: "var(--text-primary-color, #1e1e1e)",
+            outline: "none",
+          }}
+        />
+        {error && (
+          <div
+            role="alert"
+            style={{
+              fontSize: "12px",
+              color: "var(--status-error-foreground, #c4314b)",
+              marginTop: "2px",
+            }}
+          >
+            {error}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <span
+      onDoubleClick={() => {
+        setDraft(name);
+        setError(null);
+        setEditing(true);
+      }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{ display: "inline-flex", alignItems: "center", gap: "6px", cursor: "default" }}
+    >
+      {name}
+      {hovered && (
+        <span
+          aria-hidden="true"
+          title="Rename"
+          style={{ fontSize: "11px", color: "var(--palette-neutral-30, #aaa)" }}
+        >
+          ✎
+        </span>
+      )}
+    </span>
+  );
+};

--- a/src/app/EditableTagName.tsx
+++ b/src/app/EditableTagName.tsx
@@ -3,7 +3,7 @@ import { validateTagName } from "../utils/validateTagName";
 
 export interface EditableTagNameProps {
   name: string;
-  onRename: (newName: string) => void;
+  onRename: (newName: string) => void | Promise<void>;
   onCancel: () => void;
   existingNames: string[];
 }
@@ -21,7 +21,7 @@ export const EditableTagName: React.FC<EditableTagNameProps> = ({
   // Prevents blur from triggering a second commit after Enter already committed.
   const committedRef = useRef(false);
 
-  const commit = () => {
+  const commit = async () => {
     if (committedRef.current) return;
     const validation = validateTagName(draft);
     if (!validation.valid) {
@@ -38,8 +38,11 @@ export const EditableTagName: React.FC<EditableTagNameProps> = ({
     committedRef.current = true;
     setEditing(false);
     setError(null);
-    onRename(draft.trim());
-    // Reset after microtask so blur fired in the same tick is swallowed.
+    try {
+      await onRename(draft.trim());
+    } catch {
+      onCancel();
+    }
     Promise.resolve().then(() => {
       committedRef.current = false;
     });

--- a/src/app/EditableTagName.tsx
+++ b/src/app/EditableTagName.tsx
@@ -88,7 +88,6 @@ export const EditableTagName: React.FC<EditableTagNameProps> = ({
             borderRadius: "2px",
             background: "var(--callout-background-color, #fff)",
             color: "var(--text-primary-color, #1e1e1e)",
-            outline: "none",
           }}
         />
         {error && (

--- a/src/app/EditableTagName.tsx
+++ b/src/app/EditableTagName.tsx
@@ -18,6 +18,7 @@ export const EditableTagName: React.FC<EditableTagNameProps> = ({
   const [draft, setDraft] = useState(name);
   const [error, setError] = useState<string | null>(null);
   const [hovered, setHovered] = useState(false);
+  const [focused, setFocused] = useState(false);
   // Prevents blur from triggering a second commit after Enter already committed.
   const committedRef = useRef(false);
 
@@ -114,13 +115,17 @@ export const EditableTagName: React.FC<EditableTagNameProps> = ({
   return (
     <button
       type="button"
+      aria-label={`Rename tag ${name}`}
+      title="Double-click, Enter, or F2 to rename"
       onDoubleClick={startEditing}
       onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === "F2") {
+        if (e.key === "Enter" || e.key === "F2" || e.key === " ") {
           e.preventDefault();
           startEditing();
         }
       }}
+      onFocus={() => setFocused(true)}
+      onBlur={() => setFocused(false)}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       style={{
@@ -133,6 +138,11 @@ export const EditableTagName: React.FC<EditableTagNameProps> = ({
         color: "inherit",
         font: "inherit",
         padding: 0,
+        borderRadius: "2px",
+        outline: focused
+          ? "2px solid var(--communication-foreground, #0078d4)"
+          : "none",
+        outlineOffset: "2px",
       }}
     >
       {name}

--- a/src/app/EditableTagName.tsx
+++ b/src/app/EditableTagName.tsx
@@ -19,11 +19,12 @@ export const EditableTagName: React.FC<EditableTagNameProps> = ({
   const [error, setError] = useState<string | null>(null);
   const [hovered, setHovered] = useState(false);
   const [focused, setFocused] = useState(false);
-  // Prevents blur from triggering a second commit after Enter already committed.
-  const committedRef = useRef(false);
+  const isSavingRef = useRef(false);
+  // Prevents blur from triggering a second commit after keyboard commit/cancel.
+  const suppressBlurCommitRef = useRef(false);
 
   const commit = async () => {
-    if (committedRef.current) return;
+    if (isSavingRef.current) return;
     const validation = validateTagName(draft);
     if (!validation.valid) {
       setError(validation.reason ?? "Invalid tag name.");
@@ -36,29 +37,31 @@ export const EditableTagName: React.FC<EditableTagNameProps> = ({
       setError("A tag with this name already exists — use Merge instead.");
       return;
     }
-    committedRef.current = true;
     setEditing(false);
     setError(null);
+    isSavingRef.current = true;
     try {
       await onRename(draft.trim());
     } catch {
       onCancel();
     } finally {
-      committedRef.current = false;
+      isSavingRef.current = false;
     }
   };
 
   const cancel = () => {
-    committedRef.current = true;
+    suppressBlurCommitRef.current = true;
     setEditing(false);
     setDraft(name);
     setError(null);
     onCancel();
     Promise.resolve().then(() => {
-      committedRef.current = false;
+      suppressBlurCommitRef.current = false;
     });
   };
   const startEditing = () => {
+    if (isSavingRef.current) return;
+    suppressBlurCommitRef.current = false;
     setDraft(name);
     setError(null);
     setEditing(true);
@@ -78,13 +81,23 @@ export const EditableTagName: React.FC<EditableTagNameProps> = ({
           onKeyDown={(e) => {
             if (e.key === "Enter") {
               e.preventDefault();
+              suppressBlurCommitRef.current = true;
               commit();
+              Promise.resolve().then(() => {
+                suppressBlurCommitRef.current = false;
+              });
             } else if (e.key === "Escape") {
               e.preventDefault();
               cancel();
             }
           }}
-          onBlur={commit}
+          onBlur={() => {
+            if (suppressBlurCommitRef.current) {
+              suppressBlurCommitRef.current = false;
+              return;
+            }
+            commit();
+          }}
           style={{
             width: "100%",
             boxSizing: "border-box",

--- a/src/app/EditableTagName.tsx
+++ b/src/app/EditableTagName.tsx
@@ -57,6 +57,11 @@ export const EditableTagName: React.FC<EditableTagNameProps> = ({
       committedRef.current = false;
     });
   };
+  const startEditing = () => {
+    setDraft(name);
+    setError(null);
+    setEditing(true);
+  };
 
   if (editing) {
     return (
@@ -107,15 +112,28 @@ export const EditableTagName: React.FC<EditableTagNameProps> = ({
   }
 
   return (
-    <span
-      onDoubleClick={() => {
-        setDraft(name);
-        setError(null);
-        setEditing(true);
+    <button
+      type="button"
+      onDoubleClick={startEditing}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === "F2") {
+          e.preventDefault();
+          startEditing();
+        }
       }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
-      style={{ display: "inline-flex", alignItems: "center", gap: "6px", cursor: "default" }}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "6px",
+        cursor: "pointer",
+        border: "none",
+        background: "transparent",
+        color: "inherit",
+        font: "inherit",
+        padding: 0,
+      }}
     >
       {name}
       {hovered && (
@@ -127,6 +145,6 @@ export const EditableTagName: React.FC<EditableTagNameProps> = ({
           ✎
         </span>
       )}
-    </span>
+    </button>
   );
 };

--- a/src/app/EditableTagName.tsx
+++ b/src/app/EditableTagName.tsx
@@ -42,10 +42,9 @@ export const EditableTagName: React.FC<EditableTagNameProps> = ({
       await onRename(draft.trim());
     } catch {
       onCancel();
-    }
-    Promise.resolve().then(() => {
+    } finally {
       committedRef.current = false;
-    });
+    }
   };
 
   const cancel = () => {

--- a/src/app/SearchBar.test.tsx
+++ b/src/app/SearchBar.test.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SearchBar } from "./SearchBar";
+
+describe("SearchBar", () => {
+  it("renders a searchbox with default placeholder", () => {
+    render(<SearchBar value="" onChange={jest.fn()} />);
+    expect(screen.getByRole("searchbox")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Search tags…")).toBeInTheDocument();
+  });
+
+  it("renders with a custom placeholder", () => {
+    render(<SearchBar value="" onChange={jest.fn()} placeholder="Find a tag" />);
+    expect(screen.getByPlaceholderText("Find a tag")).toBeInTheDocument();
+  });
+
+  it("does not show the clear button when value is empty", () => {
+    render(<SearchBar value="" onChange={jest.fn()} />);
+    expect(screen.queryByRole("button", { name: "Clear search" })).not.toBeInTheDocument();
+  });
+
+  it("shows the clear button when value is non-empty", () => {
+    render(<SearchBar value="alpha" onChange={jest.fn()} />);
+    expect(screen.getByRole("button", { name: "Clear search" })).toBeInTheDocument();
+  });
+
+  it("calls onChange when the user types", async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(<SearchBar value="" onChange={onChange} />);
+    await user.type(screen.getByRole("searchbox"), "a");
+    expect(onChange).toHaveBeenCalledWith("a");
+  });
+
+  it("calls onChange with empty string when the clear button is clicked", async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(<SearchBar value="alpha" onChange={onChange} />);
+    await user.click(screen.getByRole("button", { name: "Clear search" }));
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+});

--- a/src/app/SearchBar.tsx
+++ b/src/app/SearchBar.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+
+interface SearchBarProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+export const SearchBar: React.FC<SearchBarProps> = ({
+  value,
+  onChange,
+  placeholder = "Search tags…",
+}) => (
+  <div
+    style={{
+      position: "relative",
+      display: "flex",
+      alignItems: "center",
+      padding: "6px 0 8px",
+      borderBottom: "1px solid var(--palette-neutral-10, #e0e0e0)",
+      marginBottom: "4px",
+    }}
+  >
+    <input
+      type="search"
+      aria-label="Search tags"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+      style={{
+        flex: 1,
+        padding: "4px 28px 4px 8px",
+        border: "1px solid var(--palette-neutral-20, #ccc)",
+        borderRadius: "2px",
+        fontSize: "13px",
+        color: "var(--text-primary-color, #1e1e1e)",
+        background: "var(--palette-neutral-0, #fff)",
+        outline: "none",
+      }}
+    />
+    {value && (
+      <button
+        aria-label="Clear search"
+        onClick={() => onChange("")}
+        style={{
+          position: "absolute",
+          right: "4px",
+          border: "none",
+          background: "none",
+          cursor: "pointer",
+          color: "var(--palette-neutral-60, #555)",
+          fontSize: "16px",
+          lineHeight: 1,
+          padding: "0 4px",
+        }}
+      >
+        ×
+      </button>
+    )}
+  </div>
+);

--- a/src/app/SearchBar.tsx
+++ b/src/app/SearchBar.tsx
@@ -40,6 +40,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({
     />
     {value && (
       <button
+        type="button"
         aria-label="Clear search"
         onClick={() => onChange("")}
         style={{

--- a/src/app/SearchBar.tsx
+++ b/src/app/SearchBar.tsx
@@ -35,7 +35,6 @@ export const SearchBar: React.FC<SearchBarProps> = ({
         fontSize: "13px",
         color: "var(--text-primary-color, #1e1e1e)",
         background: "var(--palette-neutral-0, #fff)",
-        outline: "none",
       }}
     />
     {value && (

--- a/src/app/TagManagerApp.rename.test.tsx
+++ b/src/app/TagManagerApp.rename.test.tsx
@@ -130,8 +130,7 @@ describe("TagManagerApp — rename failure", () => {
 
     await waitFor(() => {
       expect(mockTagService.renameTagById).toHaveBeenCalled();
+      expect(screen.getByText("alpha")).toBeInTheDocument();
     });
-
-    expect(screen.getByText("alpha")).toBeInTheDocument();
   });
 });

--- a/src/app/TagManagerApp.rename.test.tsx
+++ b/src/app/TagManagerApp.rename.test.tsx
@@ -89,6 +89,26 @@ describe("TagManagerApp — rename flow", () => {
       ).toBeInTheDocument();
     });
   });
+
+  it("keeps tags alphabetically ordered after a successful rename", async () => {
+    mockTagService.renameTagById.mockResolvedValue({ id: "1", name: "zeta", url: "u" });
+    const user = userEvent.setup();
+    render(<TagManagerApp />);
+
+    await waitFor(() => expect(screen.getByText("alpha")).toBeInTheDocument());
+
+    await user.dblClick(screen.getByText("alpha"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "zeta");
+    await user.keyboard("[Enter]");
+
+    await waitFor(() => {
+      const beta = screen.getByText("beta");
+      const zeta = screen.getByText("zeta");
+      expect(beta.compareDocumentPosition(zeta) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+  });
 });
 
 describe("TagManagerApp — rename failure", () => {

--- a/src/app/TagManagerApp.rename.test.tsx
+++ b/src/app/TagManagerApp.rename.test.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockTagService = {
+  getAllTags: jest.fn(),
+  getProjectName: jest.fn(),
+  deleteTagById: jest.fn(),
+  renameTagById: jest.fn(),
+  mergeTag: jest.fn(),
+  countTagAcrossProjects: jest.fn(),
+};
+
+jest.mock("../services/TagService", () => ({
+  TagService: jest.fn(() => mockTagService),
+}));
+
+import { TagManagerApp } from "./TagManagerApp";
+
+beforeEach(() => {
+  localStorage.clear();
+  Object.values(mockTagService).forEach((fn) => (fn as jest.Mock).mockReset());
+  mockTagService.getProjectName.mockResolvedValue("Demo Project");
+  mockTagService.getAllTags.mockResolvedValue([
+    { id: "1", name: "alpha", url: "u" },
+    { id: "2", name: "beta", url: "u" },
+  ]);
+  mockTagService.renameTagById.mockResolvedValue({ id: "1", name: "renamed-tag", url: "u" });
+});
+
+describe("TagManagerApp — rename flow", () => {
+  it("calls renameTagById with the correct id and new name", async () => {
+    const user = userEvent.setup();
+    render(<TagManagerApp />);
+
+    await waitFor(() => expect(screen.getByText("alpha")).toBeInTheDocument());
+
+    await user.dblClick(screen.getByText("alpha"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "renamed-tag");
+    await user.keyboard("[Enter]");
+
+    await waitFor(() => {
+      expect(mockTagService.renameTagById).toHaveBeenCalledWith("1", "renamed-tag");
+    });
+  });
+
+  it("updates the tag name in the list after a successful rename", async () => {
+    const user = userEvent.setup();
+    render(<TagManagerApp />);
+
+    await waitFor(() => expect(screen.getByText("alpha")).toBeInTheDocument());
+
+    await user.dblClick(screen.getByText("alpha"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "renamed-tag");
+    await user.keyboard("[Enter]");
+
+    await waitFor(() => {
+      expect(screen.getByText("renamed-tag")).toBeInTheDocument();
+      expect(screen.queryByText("alpha")).not.toBeInTheDocument();
+    });
+  });
+
+  it("appends a success entry to the activity log after rename", async () => {
+    const user = userEvent.setup();
+    render(<TagManagerApp />);
+
+    await waitFor(() => expect(screen.getByText("alpha")).toBeInTheDocument());
+
+    await user.dblClick(screen.getByText("alpha"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "renamed-tag");
+    await user.keyboard("[Enter]");
+
+    await waitFor(() => {
+      expect(screen.getByText(/Activity Log/)).toBeInTheDocument();
+    });
+
+    const user2 = userEvent.setup();
+    await user2.click(screen.getByText(/Activity Log/));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/✓ Renamed "alpha" → "renamed-tag"/)
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe("TagManagerApp — rename failure", () => {
+  it("appends an error log entry when renameTagById throws", async () => {
+    mockTagService.renameTagById.mockRejectedValue(new Error("permission denied"));
+    const user = userEvent.setup();
+    render(<TagManagerApp />);
+
+    await waitFor(() => expect(screen.getByText("alpha")).toBeInTheDocument());
+
+    await user.dblClick(screen.getByText("alpha"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "new-name");
+    await user.keyboard("[Enter]");
+
+    await waitFor(() => screen.getByText(/Activity Log/));
+    const user2 = userEvent.setup();
+    await user2.click(screen.getByText(/Activity Log/));
+
+    await waitFor(() => {
+      expect(screen.getByText(/✗ Failed to rename "alpha"/)).toBeInTheDocument();
+      expect(screen.getByText(/permission denied/)).toBeInTheDocument();
+    });
+  });
+
+  it("leaves the original tag name in the list when rename fails", async () => {
+    mockTagService.renameTagById.mockRejectedValue(new Error("permission denied"));
+    const user = userEvent.setup();
+    render(<TagManagerApp />);
+
+    await waitFor(() => expect(screen.getByText("alpha")).toBeInTheDocument());
+
+    await user.dblClick(screen.getByText("alpha"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "new-name");
+    await user.keyboard("[Enter]");
+
+    await waitFor(() => {
+      expect(mockTagService.renameTagById).toHaveBeenCalled();
+    });
+
+    expect(screen.getByText("alpha")).toBeInTheDocument();
+  });
+});

--- a/src/app/TagManagerApp.search.test.tsx
+++ b/src/app/TagManagerApp.search.test.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockTagService = {
+  getAllTags: jest.fn(),
+  getProjectName: jest.fn(),
+  deleteTagById: jest.fn(),
+  renameTagById: jest.fn(),
+  mergeTag: jest.fn(),
+  countTagAcrossProjects: jest.fn(),
+};
+
+jest.mock("../services/TagService", () => ({
+  TagService: jest.fn(() => mockTagService),
+}));
+
+import { TagManagerApp } from "./TagManagerApp";
+
+beforeEach(() => {
+  localStorage.clear();
+  Object.values(mockTagService).forEach((fn) => (fn as jest.Mock).mockReset());
+  mockTagService.getProjectName.mockResolvedValue("Demo Project");
+  mockTagService.getAllTags.mockResolvedValue([
+    { id: "1", name: "alpha", url: "u" },
+    { id: "2", name: "beta", url: "u" },
+    { id: "3", name: "gamma", url: "u" },
+  ]);
+});
+
+describe("TagManagerApp — search filter", () => {
+  it("renders a search input above the tag table", async () => {
+    render(<TagManagerApp />);
+    await waitFor(() => expect(screen.getByText("alpha")).toBeInTheDocument());
+    expect(screen.getByRole("searchbox")).toBeInTheDocument();
+  });
+
+  it("typing in the search box filters the tag list", async () => {
+    const user = userEvent.setup();
+    render(<TagManagerApp />);
+    await waitFor(() => expect(screen.getByText("alpha")).toBeInTheDocument());
+
+    await user.type(screen.getByRole("searchbox"), "al");
+
+    expect(screen.getByText("alpha")).toBeInTheDocument();
+    expect(screen.queryByText("beta")).not.toBeInTheDocument();
+    expect(screen.queryByText("gamma")).not.toBeInTheDocument();
+  });
+
+  it("search is case-insensitive", async () => {
+    const user = userEvent.setup();
+    render(<TagManagerApp />);
+    await waitFor(() => expect(screen.getByText("alpha")).toBeInTheDocument());
+
+    await user.type(screen.getByRole("searchbox"), "AL");
+
+    expect(screen.getByText("alpha")).toBeInTheDocument();
+    expect(screen.queryByText("beta")).not.toBeInTheDocument();
+  });
+
+  it("clicking the clear button resets the search and shows all tags", async () => {
+    const user = userEvent.setup();
+    render(<TagManagerApp />);
+    await waitFor(() => expect(screen.getByText("alpha")).toBeInTheDocument());
+
+    await user.type(screen.getByRole("searchbox"), "alpha");
+    expect(screen.queryByText("beta")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Clear search" }));
+    expect(screen.getByText("alpha")).toBeInTheDocument();
+    expect(screen.getByText("beta")).toBeInTheDocument();
+    expect(screen.getByText("gamma")).toBeInTheDocument();
+  });
+
+  it("search and alpha filter compose: only tags matching both are shown", async () => {
+    const user = userEvent.setup();
+    render(<TagManagerApp />);
+    await waitFor(() => expect(screen.getByText("alpha")).toBeInTheDocument());
+
+    // "a" matches alpha (has 'a'), beta (has 'a'), gamma (has 'a') — all three
+    // Then alpha-filter "G" keeps only tags starting with G => gamma
+    await user.type(screen.getByRole("searchbox"), "a");
+    await user.click(screen.getByRole("button", { name: "G" }));
+
+    expect(screen.getByText("gamma")).toBeInTheDocument();
+    expect(screen.queryByText("alpha")).not.toBeInTheDocument();
+    expect(screen.queryByText("beta")).not.toBeInTheDocument();
+  });
+
+  it("alpha nav disables letters not present in search results", async () => {
+    const user = userEvent.setup();
+    render(<TagManagerApp />);
+    await waitFor(() => expect(screen.getByText("alpha")).toBeInTheDocument());
+
+    // After searching "alpha", only alpha is in results — B and G buttons should be disabled
+    await user.type(screen.getByRole("searchbox"), "alpha");
+
+    expect(screen.getByRole("button", { name: "B" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "G" })).toBeDisabled();
+  });
+
+  it("changing search query resets the current page to 1", async () => {
+    mockTagService.getAllTags.mockResolvedValue(
+      Array.from({ length: 30 }, (_, i) => ({
+        id: `${i + 1}`,
+        name: `tag-${String(i + 1).padStart(2, "0")}`,
+        url: "u",
+      }))
+    );
+
+    const user = userEvent.setup();
+    render(<TagManagerApp />);
+    await waitFor(() => expect(screen.getByText("tag-01")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: "Next →" }));
+    expect(screen.getByText(/Page 2 of/)).toBeInTheDocument();
+
+    await user.type(screen.getByRole("searchbox"), "tag");
+    expect(screen.getByText(/Page 1 of/)).toBeInTheDocument();
+  });
+});

--- a/src/app/TagManagerApp.tsx
+++ b/src/app/TagManagerApp.tsx
@@ -14,6 +14,7 @@ import { DeleteDialog } from "./DeleteDialog";
 import { MergeDialog } from "./MergeDialog";
 import { CountConfirmDialog } from "./CountConfirmDialog";
 import { StatusLog } from "./StatusLog";
+import { SearchBar } from "./SearchBar";
 import { sanitizeError } from "../utils/sanitizeError";
 
 type DialogState =
@@ -52,6 +53,7 @@ export const TagManagerApp: React.FC = () => {
   const [logEntries, setLogEntries] = useState<LogEntry[]>(_initialLog);
   const [alphaFilter, setAlphaFilter] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(0);
+  const [searchQuery, setSearchQuery] = useState("");
   const [projectName, setProjectName] = useState<string>("");
   const logIdRef = useRef(_initialLogId);
   const tagsRef = useRef<TagItem[]>([]);
@@ -249,16 +251,27 @@ export const TagManagerApp: React.FC = () => {
     setCurrentPage(0);
   };
 
+  const handleSearchChange = (value: string) => {
+    setSearchQuery(value);
+    setCurrentPage(0);
+  };
+
   // --- Render ---
 
+  const searchFiltered = searchQuery.trim()
+    ? tags.filter((t) =>
+        t.name.toLowerCase().includes(searchQuery.trim().toLowerCase())
+      )
+    : tags;
+
   const filteredTags = alphaFilter
-    ? tags.filter((t) => {
+    ? searchFiltered.filter((t) => {
         const ch = t.name[0]?.toUpperCase();
         return alphaFilter === "#"
           ? !(ch >= "A" && ch <= "Z")
           : ch === alphaFilter;
       })
-    : tags;
+    : searchFiltered;
 
   const totalPages = Math.max(1, Math.ceil(filteredTags.length / PAGE_SIZE));
   const safePage = Math.min(currentPage, totalPages - 1);
@@ -310,8 +323,9 @@ export const TagManagerApp: React.FC = () => {
         )}
         <Card>
           <div style={{ display: "flex", flexDirection: "column" }}>
+            <SearchBar value={searchQuery} onChange={handleSearchChange} />
             <AlphaNav
-              tags={tags}
+              tags={searchFiltered}
               activeFilter={alphaFilter}
               onFilter={handleAlphaFilter}
             />

--- a/src/app/TagManagerApp.tsx
+++ b/src/app/TagManagerApp.tsx
@@ -54,6 +54,7 @@ export const TagManagerApp: React.FC = () => {
   const [currentPage, setCurrentPage] = useState(0);
   const [projectName, setProjectName] = useState<string>("");
   const logIdRef = useRef(_initialLogId);
+  const tagsRef = useRef<TagItem[]>([]);
 
   // Persist log whenever it changes
   useEffect(() => {
@@ -64,6 +65,10 @@ export const TagManagerApp: React.FC = () => {
       // localStorage unavailable (e.g. private browsing quota) — silently skip
     }
   }, [logEntries]);
+
+  useEffect(() => {
+    tagsRef.current = tags;
+  }, [tags]);
 
   // --- Helpers ---
 
@@ -91,7 +96,7 @@ export const TagManagerApp: React.FC = () => {
   const proj = projectName ? `[${projectName}] ` : "";
 
   const handleRename = useCallback(async (tagId: string, newName: string) => {
-    const original = tags.find((t) => t.id === tagId)?.name ?? tagId;
+    const original = tagsRef.current.find((t) => t.id === tagId)?.name ?? tagId;
     const logId = appendLog(`${proj}Renaming "${original}" → "${newName}"…`, "running");
     try {
       const updated = await tagService.renameTagById(tagId, newName);
@@ -102,7 +107,7 @@ export const TagManagerApp: React.FC = () => {
     } catch (e) {
       updateLog(logId, `${proj}✗ Failed to rename "${original}": ${sanitizeError(e)}`, "error");
     }
-  }, [tags, proj, appendLog, updateLog]);
+  }, [proj, appendLog, updateLog]);
 
   // --- Data loading ---
 

--- a/src/app/TagManagerApp.tsx
+++ b/src/app/TagManagerApp.tsx
@@ -14,6 +14,7 @@ import { DeleteDialog } from "./DeleteDialog";
 import { MergeDialog } from "./MergeDialog";
 import { CountConfirmDialog } from "./CountConfirmDialog";
 import { StatusLog } from "./StatusLog";
+import { sanitizeError } from "../utils/sanitizeError";
 
 type DialogState =
   | { type: "delete"; tags: TagItem[] }
@@ -87,6 +88,22 @@ export const TagManagerApp: React.FC = () => {
     );
   }, []);
 
+  const proj = projectName ? `[${projectName}] ` : "";
+
+  const handleRename = useCallback(async (tagId: string, newName: string) => {
+    const original = tags.find((t) => t.id === tagId)?.name ?? tagId;
+    const logId = appendLog(`${proj}Renaming "${original}" → "${newName}"…`, "running");
+    try {
+      const updated = await tagService.renameTagById(tagId, newName);
+      setTags((prev) =>
+        prev.map((t) => (t.id === tagId ? { ...t, name: updated.name } : t))
+      );
+      updateLog(logId, `${proj}✓ Renamed "${original}" → "${updated.name}"`, "success");
+    } catch (e) {
+      updateLog(logId, `${proj}✗ Failed to rename "${original}": ${sanitizeError(e)}`, "error");
+    }
+  }, [tags, proj, appendLog, updateLog]);
+
   // --- Data loading ---
 
   const loadTags = useCallback(async () => {
@@ -144,8 +161,6 @@ export const TagManagerApp: React.FC = () => {
   };
 
   // --- Background jobs ---
-
-  const proj = projectName ? `[${projectName}] ` : "";
 
   const runDeleteJobs = async (tagsToDelete: TagItem[]) => {
     setDialog(null);
@@ -305,6 +320,8 @@ export const TagManagerApp: React.FC = () => {
                 selectedIds={selectedIds}
                 onToggle={handleToggle}
                 onToggleAll={handleToggleAll}
+                onRename={handleRename}
+                existingNames={tags.map((t) => t.name)}
               />
             )}
             {!loading && totalPages > 1 && (

--- a/src/app/TagManagerApp.tsx
+++ b/src/app/TagManagerApp.tsx
@@ -103,7 +103,9 @@ export const TagManagerApp: React.FC = () => {
     try {
       const updated = await tagService.renameTagById(tagId, newName);
       setTags((prev) =>
-        prev.map((t) => (t.id === tagId ? { ...t, name: updated.name } : t))
+        prev
+          .map((t) => (t.id === tagId ? { ...t, name: updated.name } : t))
+          .sort((a, b) => a.name.localeCompare(b.name))
       );
       updateLog(logId, `${proj}✓ Renamed "${original}" → "${updated.name}"`, "success");
     } catch (e) {

--- a/src/app/TagManagerApp.tsx
+++ b/src/app/TagManagerApp.tsx
@@ -1,5 +1,5 @@
 // src/app/TagManagerApp.tsx
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Card } from "azure-devops-ui/Card";
 import { Header, TitleSize } from "azure-devops-ui/Header";
 import { IHeaderCommandBarItem } from "azure-devops-ui/HeaderCommandBar";
@@ -263,6 +263,7 @@ export const TagManagerApp: React.FC = () => {
         t.name.toLowerCase().includes(searchQuery.trim().toLowerCase())
       )
     : tags;
+  const existingNames = useMemo(() => tags.map((t) => t.name), [tags]);
 
   const filteredTags = alphaFilter
     ? searchFiltered.filter((t) => {
@@ -340,7 +341,7 @@ export const TagManagerApp: React.FC = () => {
                 onToggle={handleToggle}
                 onToggleAll={handleToggleAll}
                 onRename={handleRename}
-                existingNames={tags.map((t) => t.name)}
+                existingNames={existingNames}
               />
             )}
             {!loading && totalPages > 1 && (

--- a/src/app/TagTable.test.tsx
+++ b/src/app/TagTable.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { TagTable } from "./TagTable";
 
@@ -40,5 +41,58 @@ describe("TagTable", () => {
 
     expect(onToggleAll).toHaveBeenCalled();
     expect(onToggle).toHaveBeenCalledWith("1");
+  });
+});
+
+describe("TagTable — rename wiring", () => {
+  it("renders EditableTagName when onRename is provided", async () => {
+    const user = userEvent.setup();
+    const onRename = jest.fn();
+    render(
+      <TagTable
+        tags={[{ id: "1", name: "alpha", url: "u1" }]}
+        selectedIds={new Set()}
+        onToggle={jest.fn()}
+        onToggleAll={jest.fn()}
+        onRename={onRename}
+        existingNames={["alpha"]}
+      />
+    );
+    await user.dblClick(screen.getByText("alpha"));
+    expect(screen.getByRole("textbox", { name: "Edit tag name" })).toBeInTheDocument();
+  });
+
+  it("renders plain text when onRename is not provided", () => {
+    render(
+      <TagTable
+        tags={[{ id: "1", name: "alpha", url: "u1" }]}
+        selectedIds={new Set()}
+        onToggle={jest.fn()}
+        onToggleAll={jest.fn()}
+      />
+    );
+    expect(screen.getByText("alpha")).toBeInTheDocument();
+    expect(screen.queryByTitle("Rename")).not.toBeInTheDocument();
+  });
+
+  it("calls onRename with tagId and new name when rename is committed", async () => {
+    const user = userEvent.setup();
+    const onRename = jest.fn();
+    render(
+      <TagTable
+        tags={[{ id: "tag-1", name: "alpha", url: "u1" }]}
+        selectedIds={new Set()}
+        onToggle={jest.fn()}
+        onToggleAll={jest.fn()}
+        onRename={onRename}
+        existingNames={["alpha"]}
+      />
+    );
+    await user.dblClick(screen.getByText("alpha"));
+    const input = screen.getByRole("textbox", { name: "Edit tag name" });
+    await user.clear(input);
+    await user.type(input, "beta");
+    await user.keyboard("[Enter]");
+    expect(onRename).toHaveBeenCalledWith("tag-1", "beta");
   });
 });

--- a/src/app/TagTable.tsx
+++ b/src/app/TagTable.tsx
@@ -19,7 +19,7 @@ interface TagTableProps {
   selectedIds: Set<string>;
   onToggle: (id: string) => void;
   onToggleAll: (select: boolean) => void;
-  onRename?: (tagId: string, newName: string) => void;
+  onRename?: (tagId: string, newName: string) => void | Promise<void>;
   existingNames?: string[];
 }
 

--- a/src/app/TagTable.tsx
+++ b/src/app/TagTable.tsx
@@ -12,12 +12,15 @@ import { Checkbox } from "azure-devops-ui/Checkbox";
 import { ZeroData } from "azure-devops-ui/ZeroData";
 import { Spinner, SpinnerSize } from "azure-devops-ui/Spinner";
 import { TagItem } from "../types";
+import { EditableTagName } from "./EditableTagName";
 
 interface TagTableProps {
   tags: TagItem[];
   selectedIds: Set<string>;
   onToggle: (id: string) => void;
   onToggleAll: (select: boolean) => void;
+  onRename?: (tagId: string, newName: string) => void;
+  existingNames?: string[];
 }
 
 // Column widths are stable ObservableValues — defined outside the component
@@ -30,6 +33,8 @@ export const TagTable: React.FC<TagTableProps> = ({
   selectedIds,
   onToggle,
   onToggleAll,
+  onRename,
+  existingNames = [],
 }) => {
   if (tags.length === 0) {
     return (
@@ -89,7 +94,16 @@ export const TagTable: React.FC<TagTableProps> = ({
           tableColumn={tableColumn}
           key={`name-${item.id}`}
         >
-          {item.name}
+          {onRename ? (
+            <EditableTagName
+              name={item.name}
+              onRename={(newName) => onRename(item.id, newName)}
+              onCancel={() => {}}
+              existingNames={existingNames}
+            />
+          ) : (
+            item.name
+          )}
         </SimpleTableCell>
       ),
       readonly: true,
@@ -117,7 +131,7 @@ export const TagTable: React.FC<TagTableProps> = ({
       width: -1,
     },
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  ], [selectedIds, onToggle, onToggleAll, allSelected, someSelected]);
+  ], [selectedIds, onToggle, onToggleAll, allSelected, someSelected, onRename, existingNames]);
 
   return (
     <Table<TagItem>

--- a/src/app/TagTable.tsx
+++ b/src/app/TagTable.tsx
@@ -14,14 +14,22 @@ import { Spinner, SpinnerSize } from "azure-devops-ui/Spinner";
 import { TagItem } from "../types";
 import { EditableTagName } from "./EditableTagName";
 
-interface TagTableProps {
+type TagTableBaseProps = {
   tags: TagItem[];
   selectedIds: Set<string>;
   onToggle: (id: string) => void;
   onToggleAll: (select: boolean) => void;
-  onRename?: (tagId: string, newName: string) => void | Promise<void>;
-  existingNames?: string[];
-}
+};
+
+type TagTableProps =
+  | (TagTableBaseProps & {
+      onRename: (tagId: string, newName: string) => void | Promise<void>;
+      existingNames: string[];
+    })
+  | (TagTableBaseProps & {
+      onRename?: undefined;
+      existingNames?: string[];
+    });
 
 // Column widths are stable ObservableValues — defined outside the component
 // so they are not recreated on every render (prevents ADO Table column flicker).
@@ -29,15 +37,9 @@ const colWidthSelect = new ObservableValue(48);
 const colWidthName = new ObservableValue(300);
 const EMPTY_NAMES: string[] = [];
 
-export const TagTable: React.FC<TagTableProps> = ({
-  tags,
-  selectedIds,
-  onToggle,
-  onToggleAll,
-  onRename,
-  existingNames: existingNamesProp,
-}) => {
-  const existingNames = existingNamesProp ?? EMPTY_NAMES;
+export const TagTable: React.FC<TagTableProps> = (props) => {
+  const { tags, selectedIds, onToggle, onToggleAll, onRename } = props;
+  const existingNames = onRename ? props.existingNames : EMPTY_NAMES;
 
   if (tags.length === 0) {
     return (

--- a/src/app/TagTable.tsx
+++ b/src/app/TagTable.tsx
@@ -27,6 +27,7 @@ interface TagTableProps {
 // so they are not recreated on every render (prevents ADO Table column flicker).
 const colWidthSelect = new ObservableValue(48);
 const colWidthName = new ObservableValue(300);
+const EMPTY_NAMES: string[] = [];
 
 export const TagTable: React.FC<TagTableProps> = ({
   tags,
@@ -34,8 +35,10 @@ export const TagTable: React.FC<TagTableProps> = ({
   onToggle,
   onToggleAll,
   onRename,
-  existingNames = [],
+  existingNames: existingNamesProp,
 }) => {
+  const existingNames = existingNamesProp ?? EMPTY_NAMES;
+
   if (tags.length === 0) {
     return (
       <ZeroData

--- a/src/utils/sanitizeError.test.ts
+++ b/src/utils/sanitizeError.test.ts
@@ -21,4 +21,19 @@ describe("sanitizeError", () => {
     const result = sanitizeError(new Error("first line\nat: somewhere"));
     expect(result).toBe("first line");
   });
+
+  it("redacts URLs", () => {
+    const result = sanitizeError(new Error("request failed at https://contoso.example/api?token=abc123"));
+    expect(result).toBe("request failed at [redacted-url]");
+  });
+
+  it("redacts bearer tokens", () => {
+    const result = sanitizeError(new Error("Unauthorized: Bearer abc123.xyz"));
+    expect(result).toBe("Unauthorized: Bearer [redacted]");
+  });
+
+  it("redacts token-like key/value pairs", () => {
+    const result = sanitizeError(new Error("permission denied token=abc123 authorization:secret"));
+    expect(result).toBe("permission denied token=[redacted] authorization=[redacted]");
+  });
 });

--- a/src/utils/sanitizeError.test.ts
+++ b/src/utils/sanitizeError.test.ts
@@ -27,6 +27,21 @@ describe("sanitizeError", () => {
     expect(result).toBe("request failed at [redacted-url]");
   });
 
+  it("redacts credentialed URLs", () => {
+    const result = sanitizeError(new Error("failed: https://user:password@contoso.example/path"));
+    expect(result).toBe("failed: [redacted-url]");
+  });
+
+  it("redacts URLs wrapped with angle brackets or quotes", () => {
+    const result = sanitizeError(new Error("failed at <\"https://contoso.example/path\">"));
+    expect(result).toBe("failed at <\"[redacted-url]\">");
+  });
+
+  it("redacts URLs followed by closing brackets", () => {
+    const result = sanitizeError(new Error("failed at [https://contoso.example/path]"));
+    expect(result).toBe("failed at [[redacted-url]]");
+  });
+
   it("redacts bearer tokens", () => {
     const result = sanitizeError(new Error("Unauthorized: Bearer abc123.xyz"));
     expect(result).toBe("Unauthorized: Bearer [redacted]");

--- a/src/utils/sanitizeError.test.ts
+++ b/src/utils/sanitizeError.test.ts
@@ -1,0 +1,24 @@
+import { sanitizeError } from "./sanitizeError";
+
+describe("sanitizeError", () => {
+  it("returns the message from an Error", () => {
+    expect(sanitizeError(new Error("something went wrong"))).toBe(
+      "something went wrong"
+    );
+  });
+
+  it("stringifies non-Error values", () => {
+    expect(sanitizeError("raw string")).toBe("raw string");
+    expect(sanitizeError(42)).toBe("42");
+  });
+
+  it("truncates messages longer than 200 characters", () => {
+    const result = sanitizeError(new Error("x".repeat(300)));
+    expect(result.length).toBeLessThanOrEqual(200);
+  });
+
+  it("strips content after the first newline", () => {
+    const result = sanitizeError(new Error("first line\nat: somewhere"));
+    expect(result).toBe("first line");
+  });
+});

--- a/src/utils/sanitizeError.ts
+++ b/src/utils/sanitizeError.ts
@@ -1,7 +1,7 @@
 export function sanitizeError(raw: unknown): string {
   const msg = raw instanceof Error ? raw.message : String(raw);
   const firstLine = msg.split("\n")[0];
-  const withoutUrls = firstLine.replace(/\bhttps?:\/\/\S+/gi, "[redacted-url]");
+  const withoutUrls = firstLine.replace(/\bhttps?:\/\/[^\s,;)>"'\]]+/gi, "[redacted-url]");
   const withoutBearer = withoutUrls.replace(/\bBearer\s+[^\s,;]+/gi, "Bearer [redacted]");
   const withoutTokens = withoutBearer.replace(
     /\b(token|pat|api[_-]?key|authorization)\s*[:=]\s*[^\s,;]+/gi,

--- a/src/utils/sanitizeError.ts
+++ b/src/utils/sanitizeError.ts
@@ -1,5 +1,11 @@
 export function sanitizeError(raw: unknown): string {
   const msg = raw instanceof Error ? raw.message : String(raw);
   const firstLine = msg.split("\n")[0];
-  return firstLine.slice(0, 200);
+  const withoutUrls = firstLine.replace(/\bhttps?:\/\/\S+/gi, "[redacted-url]");
+  const withoutBearer = withoutUrls.replace(/\bBearer\s+[^\s,;]+/gi, "Bearer [redacted]");
+  const withoutTokens = withoutBearer.replace(
+    /\b(token|pat|api[_-]?key|authorization)\s*[:=]\s*[^\s,;]+/gi,
+    "$1=[redacted]"
+  );
+  return withoutTokens.slice(0, 200);
 }

--- a/src/utils/sanitizeError.ts
+++ b/src/utils/sanitizeError.ts
@@ -1,0 +1,5 @@
+export function sanitizeError(raw: unknown): string {
+  const msg = raw instanceof Error ? raw.message : String(raw);
+  const firstLine = msg.split("\n")[0];
+  return firstLine.slice(0, 200);
+}

--- a/src/utils/validateTagName.test.ts
+++ b/src/utils/validateTagName.test.ts
@@ -1,0 +1,33 @@
+import { validateTagName } from "./validateTagName";
+
+describe("validateTagName", () => {
+  it("accepts a normal tag name", () => {
+    expect(validateTagName("bug")).toEqual({ valid: true });
+  });
+
+  it("rejects an empty string", () => {
+    const result = validateTagName("   ");
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBeTruthy();
+  });
+
+  it("rejects a name longer than 256 characters", () => {
+    const result = validateTagName("a".repeat(257));
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/256/);
+  });
+
+  it("rejects a name that contains a semicolon", () => {
+    const result = validateTagName("bug;feature");
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/semicolon/i);
+  });
+
+  it("accepts a name that is exactly 256 characters", () => {
+    expect(validateTagName("a".repeat(256))).toEqual({ valid: true });
+  });
+
+  it("accepts a name with spaces and hyphens", () => {
+    expect(validateTagName("payment-gateway v2")).toEqual({ valid: true });
+  });
+});

--- a/src/utils/validateTagName.ts
+++ b/src/utils/validateTagName.ts
@@ -1,0 +1,21 @@
+export interface ValidationResult {
+  valid: boolean;
+  reason?: string;
+}
+
+export function validateTagName(name: string): ValidationResult {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) {
+    return { valid: false, reason: "Tag name cannot be empty." };
+  }
+  if (trimmed.length > 256) {
+    return { valid: false, reason: "Tag name cannot exceed 256 characters." };
+  }
+  if (trimmed.includes(";")) {
+    return {
+      valid: false,
+      reason: 'Tag names cannot contain semicolons — ADO uses ";" to separate tags.',
+    };
+  }
+  return { valid: true };
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "types": ["jest", "node"],
+    "types": ["jest", "node", "@testing-library/jest-dom"],
     "noEmit": true
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
## Summary

- **Feature A — Inline Rename:** Double-click any tag name to rename it in place. Enter commits, Escape cancels. Validates against empty/too-long/semicolon names and duplicate detection (suggests Merge). Calls `TagService.renameTagById`; activity log records success or failure.
- **Feature B — Text Search Filter:** Free-text search bar above the alpha-nav filters tags client-side, instantly. Case-insensitive substring match. AlphaNav disabled-letter state reflects search results. Clearing the search restores all tags. Changing the query resets pagination to page 1.
- Supporting utilities: `validateTagName` (ADO name rules), `sanitizeError` (strips URLs/stack traces from user-facing errors).

## Test Plan

- [ ] 70 tests across 14 suites pass (`pnpm test`)
- [ ] Double-click a tag name → input appears pre-filled with current name
- [ ] Type new name → Enter commits; tag updates in list and activity log shows ✓
- [ ] Escape while editing → reverts to original name, no API call
- [ ] Duplicate name → inline error: "A tag with this name already exists — use Merge instead."
- [ ] API failure during rename → activity log shows ✗, tag name reverts in UI
- [ ] Type in search box → list filters instantly (case-insensitive)
- [ ] Alpha-nav letters absent from search results are disabled
- [ ] Clear (×) button restores full list
- [ ] Navigating to page 2 then typing in search → returns to page 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)