### PR TITLE
Implement clickable merge target selection and improve accessibility

### DIFF
--- a/docs/superpowers/plans/2026-07-04-merge-target-pill.md
+++ b/docs/superpowers/plans/2026-07-04-merge-target-pill.md
@@ -1,0 +1,507 @@
+# Merge Dialog — Click-to-Select Target Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the user click a source pill in the Merge Tags dialog to set it as the merge target, instead of always having to type/select the target name in the separate search field.
+
+**Architecture:** `MergeDialog.tsx` already tracks the target as a single `targetName` string. Clicking a source pill reuses the existing `selectSuggestion` state-setting path, so the pill click and the text field become two inputs to the same piece of state — no new state variable is needed, just new rendering/interaction on the source pills and a corrected `isValid`/count calculation. Separately, `TagManagerApp.tsx` gets a one-line filter fix so a source chosen as its own target is never also sent to the batch-merge/delete call.
+
+**Tech Stack:** React (function components, hooks), TypeScript, Jest + React Testing Library, `azure-devops-ui` component library (mocked in tests via `src/test/mocks/modules/azureDevopsUi.tsx`).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-04-merge-target-pill-design.md`
+- Do not change `TagService.mergeTags` itself — the fix is filtering the `sources` array passed into it, at the call site in `TagManagerApp.tsx`.
+- Selected-target pill must render with `PillVariant.standard` and `iconProps.iconName: "CheckMark"`; unselected pills keep `PillVariant.outlined` and `iconProps.iconName: "Tag"` (unchanged from today).
+- Pills must be operable by both click and keyboard (`Enter`/`Space`), with `role="button"` and `tabIndex={0}`.
+- Merge button stays disabled unless there is at least one tag left to merge into the target (existing `isValid` was `trimmed.length > 0`; this must now also require ≥1 remaining source after excluding the target).
+
+---
+
+### Task 1: Make source pills clickable to select/deselect the target, with correct count and validity
+
+**Files:**
+- Modify: `src/app/MergeDialog.tsx:22-118`
+- Modify: `src/test/mocks/modules/azureDevopsUi.tsx:270-278` (expose `variant`/`iconProps` on the mocked `Pill` so tests can assert selected styling)
+- Test: `src/app/MergeDialog.test.tsx`
+
+**Interfaces:**
+- Consumes: nothing new — reuses the existing `selectSuggestion(name: string)` function already defined in `MergeDialog.tsx:51-54`.
+- Produces: nothing consumed by other tasks — Task 2 only relies on `MergeDialog`'s existing public `onConfirm: (targetName: string) => void` prop, which is unchanged.
+
+- [ ] **Step 1: Update the mocked `Pill` component to surface `variant` and `iconProps` for assertions**
+
+In `src/test/mocks/modules/azureDevopsUi.tsx`, replace the `Pill` mock (lines 270-278):
+
+```tsx
+export const Pill: React.FC<
+  React.PropsWithChildren<{
+    size?: number;
+    variant?: number;
+    iconProps?: { iconName: string };
+    className?: string;
+  }>
+> = ({ children }) => <span data-testid="pill">{children}</span>;
+```
+
+with:
+
+```tsx
+export const Pill: React.FC<
+  React.PropsWithChildren<{
+    size?: number;
+    variant?: number;
+    iconProps?: { iconName: string };
+    className?: string;
+  }>
+> = ({ children, variant, iconProps }) => (
+  <span data-testid="pill" data-variant={variant} data-icon={iconProps?.iconName}>
+    {children}
+  </span>
+);
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Add to `src/app/MergeDialog.test.tsx` (new `import { PillVariant } from "azure-devops-ui/Pill";` at the top, alongside the existing imports):
+
+```tsx
+import { PillVariant } from "azure-devops-ui/Pill";
+```
+
+Then add these `it` blocks inside the existing `describe("MergeDialog", ...)` block:
+
+```tsx
+  it("selects a source tag as the target when its pill is clicked", () => {
+    const onConfirm = jest.fn();
+    const twoSources = [
+      { id: "1", name: "one", url: "u" },
+      { id: "2", name: "two", url: "u" },
+    ];
+
+    render(
+      <MergeDialog
+        sources={twoSources}
+        allTags={[]}
+        onConfirm={onConfirm}
+        onCancel={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "one" }));
+
+    expect(
+      screen.getByPlaceholderText("Type to search or create a tag")
+    ).toHaveValue("one");
+    expect(screen.getByText("1 tag will be merged")).toBeInTheDocument();
+
+    const targetPill = screen.getByText("one").closest('[data-testid="pill"]');
+    expect(targetPill).toHaveAttribute("data-variant", String(PillVariant.standard));
+    expect(targetPill).toHaveAttribute("data-icon", "CheckMark");
+
+    fireEvent.click(screen.getByRole("button", { name: "Merge" }));
+    expect(onConfirm).toHaveBeenCalledWith("one");
+  });
+
+  it("deselects a source pill when it is clicked again", () => {
+    const twoSources = [
+      { id: "1", name: "one", url: "u" },
+      { id: "2", name: "two", url: "u" },
+    ];
+
+    render(
+      <MergeDialog
+        sources={twoSources}
+        allTags={[]}
+        onConfirm={jest.fn()}
+        onCancel={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "one" }));
+    fireEvent.click(screen.getByRole("button", { name: "one" }));
+
+    expect(
+      screen.getByPlaceholderText("Type to search or create a tag")
+    ).toHaveValue("");
+    expect(screen.getByText("2 tags will be merged")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Merge" })).toBeDisabled();
+  });
+
+  it("disables Merge when the only source is selected as its own target", () => {
+    const oneSource = [{ id: "1", name: "solo", url: "u" }];
+
+    render(
+      <MergeDialog
+        sources={oneSource}
+        allTags={[]}
+        onConfirm={jest.fn()}
+        onCancel={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "solo" }));
+
+    expect(screen.getByRole("button", { name: "Merge" })).toBeDisabled();
+  });
+
+  it("supports selecting a source pill via the keyboard", () => {
+    const onConfirm = jest.fn();
+    const twoSources = [
+      { id: "1", name: "one", url: "u" },
+      { id: "2", name: "two", url: "u" },
+    ];
+
+    render(
+      <MergeDialog
+        sources={twoSources}
+        allTags={[]}
+        onConfirm={onConfirm}
+        onCancel={jest.fn()}
+      />
+    );
+
+    fireEvent.keyDown(screen.getByRole("button", { name: "one" }), { key: "Enter" });
+
+    expect(
+      screen.getByPlaceholderText("Type to search or create a tag")
+    ).toHaveValue("one");
+  });
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pnpm test -- MergeDialog.test.tsx`
+Expected: FAIL — `screen.getByRole("button", { name: "one" })` finds no matching element (source pills aren't currently interactive/focusable elements with that accessible name).
+
+- [ ] **Step 4: Implement the pill click/keyboard handling, count label, and validity check**
+
+In `src/app/MergeDialog.tsx`, replace lines 22-44:
+
+```tsx
+  const [targetName, setTargetName] = useState("");
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+
+  const trimmed = targetName.trim();
+
+  const suggestions = allTags.filter((t) => {
+    if (sources.some((source) => source.id === t.id)) {
+      return false;
+    }
+
+    if (trimmed.length === 0) {
+      return true;
+    }
+
+    return t.name.toLowerCase().includes(trimmed.toLowerCase());
+  });
+
+  const isNewTag =
+    trimmed.length > 0 &&
+    !allTags.some((t) => t.name.toLowerCase() === trimmed.toLowerCase());
+
+  const totalItems = suggestions.length + (isNewTag ? 1 : 0);
+  const isValid = trimmed.length > 0;
+```
+
+with:
+
+```tsx
+  const [targetName, setTargetName] = useState("");
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+
+  const trimmed = targetName.trim();
+
+  const suggestions = allTags.filter((t) => {
+    if (sources.some((source) => source.id === t.id)) {
+      return false;
+    }
+
+    if (trimmed.length === 0) {
+      return true;
+    }
+
+    return t.name.toLowerCase().includes(trimmed.toLowerCase());
+  });
+
+  const isNewTag =
+    trimmed.length > 0 &&
+    !allTags.some((t) => t.name.toLowerCase() === trimmed.toLowerCase());
+
+  const totalItems = suggestions.length + (isNewTag ? 1 : 0);
+
+  const targetIsSource = sources.some(
+    (t) => t.name.toLowerCase() === trimmed.toLowerCase()
+  );
+  const remainingSourceCount = targetIsSource ? sources.length - 1 : sources.length;
+  const isValid = trimmed.length > 0 && remainingSourceCount > 0;
+```
+
+Then add a click/keyboard handler alongside the existing `selectSuggestion` (right after it, currently lines 51-54):
+
+```tsx
+  const selectSuggestion = (name: string) => {
+    setTargetName(name);
+    setHighlightedIndex(-1);
+  };
+
+  const handlePillClick = (name: string) => {
+    if (trimmed.toLowerCase() === name.toLowerCase()) {
+      setTargetName("");
+    } else {
+      selectSuggestion(name);
+    }
+  };
+
+  const handlePillKeyDown = (
+    e: React.KeyboardEvent<HTMLDivElement>,
+    name: string
+  ) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handlePillClick(name);
+    }
+  };
+```
+
+Then replace the count label and source pill row (currently lines 105-118):
+
+```tsx
+      <div
+        style={{
+          fontSize: "11px",
+          fontWeight: 600,
+          textTransform: "uppercase",
+          letterSpacing: "0.5px",
+          color: "var(--palette-neutral-60, #666)",
+          margin: "12px 0 8px",
+        }}
+      >
+        {sources.length} tag{sources.length !== 1 ? "s" : ""} will be merged
+      </div>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: "6px", margin: "0 0 16px" }}>
+        {sources.map((t) => (
+          <Pill
+            key={t.id}
+            size={PillSize.regular}
+            variant={PillVariant.outlined}
+            iconProps={{ iconName: "Tag" }}
+          >
+            {t.name}
+          </Pill>
+        ))}
+      </div>
+```
+
+with:
+
+```tsx
+      <div
+        style={{
+          fontSize: "11px",
+          fontWeight: 600,
+          textTransform: "uppercase",
+          letterSpacing: "0.5px",
+          color: "var(--palette-neutral-60, #666)",
+          margin: "12px 0 8px",
+        }}
+      >
+        {remainingSourceCount} tag{remainingSourceCount !== 1 ? "s" : ""} will be merged
+      </div>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: "6px", margin: "0 0 16px" }}>
+        {sources.map((t) => {
+          const isTarget = t.name.toLowerCase() === trimmed.toLowerCase();
+          return (
+            <div
+              key={t.id}
+              role="button"
+              tabIndex={0}
+              onClick={() => handlePillClick(t.name)}
+              onKeyDown={(e) => handlePillKeyDown(e, t.name)}
+              title={
+                isTarget
+                  ? "Target — other tags will be merged into this one"
+                  : undefined
+              }
+              style={{ cursor: "pointer", display: "inline-flex" }}
+            >
+              <Pill
+                size={PillSize.regular}
+                variant={isTarget ? PillVariant.standard : PillVariant.outlined}
+                iconProps={{ iconName: isTarget ? "CheckMark" : "Tag" }}
+              >
+                {t.name}
+              </Pill>
+            </div>
+          );
+        })}
+      </div>
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm test -- MergeDialog.test.tsx`
+Expected: PASS (all 7 tests: the 3 pre-existing plus the 4 added in Step 2).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app/MergeDialog.tsx src/app/MergeDialog.test.tsx src/test/mocks/modules/azureDevopsUi.tsx
+git commit -m "feat: click a source pill in Merge dialog to select it as the target"
+```
+
+---
+
+### Task 2: Exclude the selected target from the sources sent to the batch merge call
+
+**Files:**
+- Modify: `src/app/TagManagerApp.tsx:321-328`
+- Test: `src/app/TagManagerApp.test.tsx:4-10` (mock setup), and a new test appended near the other Merge-related tests.
+
+**Interfaces:**
+- Consumes: `MergeDialog`'s `onConfirm: (targetName: string) => void` prop (unchanged from Task 1) and the existing `runMergeJobs(sources: TagItem[], targetName: string)` function already defined in `TagManagerApp.tsx:155`.
+- Produces: nothing consumed by later tasks (this is the last task).
+
+- [ ] **Step 1: Add a `mergeTags` mock to the test file**
+
+In `src/app/TagManagerApp.test.tsx`, replace lines 4-10:
+
+```tsx
+const mockTagService = {
+  getAllTags: jest.fn(),
+  getProjectName: jest.fn(),
+  deleteTagById: jest.fn(),
+  renameTagById: jest.fn(),
+  mergeTag: jest.fn(),
+};
+```
+
+with:
+
+```tsx
+const mockTagService = {
+  getAllTags: jest.fn(),
+  getProjectName: jest.fn(),
+  deleteTagById: jest.fn(),
+  renameTagById: jest.fn(),
+  mergeTag: jest.fn(),
+  mergeTags: jest.fn(),
+};
+```
+
+Then, in the `beforeEach` block, right after the existing `mockTagService.mergeTag.mockResolvedValue(...)` (around line 41), add:
+
+```tsx
+    mockTagService.mergeTags.mockResolvedValue({ succeeded: [], failed: [] });
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Add this `it` block to `src/app/TagManagerApp.test.tsx`, inside the `describe("TagManagerApp", ...)` block (e.g. right after the "renders Merge before Delete in the command bar" test):
+
+```tsx
+  it("excludes the tag selected as target from the sources sent to mergeTags", async () => {
+    mockTagService.getAllTags.mockResolvedValue([
+      { id: "1", name: "one", url: "u" },
+      { id: "2", name: "two", url: "u" },
+    ]);
+
+    render(<TagManagerApp />);
+
+    await waitFor(() => {
+      expect(screen.getByText("one")).toBeInTheDocument();
+    });
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    fireEvent.click(checkboxes[1]); // row for "one"
+    fireEvent.click(checkboxes[2]); // row for "two"
+
+    fireEvent.click(screen.getByRole("button", { name: /^Merge/ }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "one" }));
+    fireEvent.click(screen.getByRole("button", { name: "Merge" }));
+
+    await waitFor(() => {
+      expect(mockTagService.mergeTags).toHaveBeenCalledWith(
+        [{ id: "2", name: "two", url: "u" }],
+        "one"
+      );
+    });
+  });
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm test -- TagManagerApp.test.tsx`
+Expected: FAIL — `mergeTags` is called with both `{ id: "1", name: "one", url: "u" }` and `{ id: "2", name: "two", url: "u" }` (the target is not yet excluded), so the `toHaveBeenCalledWith` assertion fails on the array contents.
+
+- [ ] **Step 4: Filter the target out of `dialog.sources` before calling `runMergeJobs`**
+
+In `src/app/TagManagerApp.tsx`, replace lines 321-328:
+
+```tsx
+      {dialog?.type === "merge" && (
+        <MergeDialog
+          sources={dialog.sources}
+          allTags={tags}
+          onConfirm={(targetName) => runMergeJobs(dialog.sources, targetName)}
+          onCancel={() => setDialog(null)}
+        />
+      )}
+```
+
+with:
+
+```tsx
+      {dialog?.type === "merge" && (
+        <MergeDialog
+          sources={dialog.sources}
+          allTags={tags}
+          onConfirm={(targetName) =>
+            runMergeJobs(
+              dialog.sources.filter(
+                (s) => s.name.toLowerCase() !== targetName.toLowerCase()
+              ),
+              targetName
+            )
+          }
+          onCancel={() => setDialog(null)}
+        />
+      )}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm test -- TagManagerApp.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full test suite**
+
+Run: `pnpm test`
+Expected: PASS — no regressions in `MergeDialog.test.tsx`, `TagManagerApp.test.tsx`, `TagManagerApp.rename.test.tsx`, `TagManagerApp.search.test.tsx`, `TagTable.test.tsx`, or `TagService.test.ts`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/app/TagManagerApp.tsx src/app/TagManagerApp.test.tsx
+git commit -m "fix: never send the merge target back to mergeTags as a source"
+```
+
+---
+
+## Manual Verification (after both tasks)
+
+Run the dev build (see project README/`run` skill for the exact command) and, in the tag manager UI:
+
+1. Select 2 tags, click Merge — confirm both source pills render outlined with a Tag icon.
+2. Click one pill — confirm it switches to a filled/checkmark style, the count label reads "1 tag will be merged", and the target input shows that tag's name.
+3. Click the same pill again — confirm it reverts to outlined, count label reads "2 tags will be merged", and Merge disables.
+4. Click a pill, then type an unrelated existing tag name into the search field — confirm the pill reverts to outlined (no longer selected).
+5. With one pill selected as target, click Merge — confirm only the *other* tag is merged and removed from the table, and the target tag still exists afterward.
+6. Select only 1 tag, open Merge, click its own pill — confirm Merge stays disabled.
+7. Tab to a pill and press Enter — confirm it selects, matching a click.
+8. Check both light and dark theme — the filled pill variant should remain legible in both.

--- a/docs/superpowers/specs/2026-07-04-merge-target-pill-design.md
+++ b/docs/superpowers/specs/2026-07-04-merge-target-pill-design.md
@@ -1,0 +1,60 @@
+# Merge Dialog — Click-to-Select Target — Design Spec
+
+**Date:** 2026-07-04
+**Status:** Approved
+
+## Context
+
+In the Merge Tags dialog (`src/app/MergeDialog.tsx`), the selected tags to merge are shown as a static row of pills (e.g. `1`, `2`), and the user must separately type or pick the destination tag name in the "Target tag" search field below. There is no way to say "merge tag 2 into tag 1" by simply clicking tag 1 — the user has to type its name even though it's already visible right above.
+
+This spec adds click-to-select: clicking one of the source pills sets it as the merge target directly, while keeping the existing search/create-new field for merging into a different existing tag or a brand-new one.
+
+## Behaviour
+
+- Every pill in the "N tags will be merged" row becomes clickable (`cursor: pointer`, hover highlight, `role="button"`, `tabIndex={0}`, Enter/Space activates it — same accessibility treatment as the existing suggestion rows).
+- Clicking a source pill calls the existing `selectSuggestion(name)` (sets `targetName` to that tag's name), the same code path already used when picking a suggestion from the list below.
+- Clicking the pill that is *already* the current target deselects it (clears `targetName` back to `""`).
+- Typing in the text field, or picking a suggestion from the list below, still works exactly as today and overrides any pill-selected target — both read/write the same `targetName` state, so only one can be "the" target at a time.
+- A pill is rendered as **selected** when `t.name.toLowerCase() === trimmed.toLowerCase()`. Selected style: switch `PillVariant.outlined` → `PillVariant.standard` (filled) and add a checkmark `iconProps` (or an adjacent small check glyph) plus a tooltip: "Target — other tags will be merged into this one". Unselected pills keep the current outlined style.
+- The count label above the pill row changes from a static "N tags will be merged" to a computed count that **excludes** the pill currently selected as target (if any): `sources.length - (isSourceSelectedAsTarget ? 1 : 0)`. Example: 2 sources, one clicked as target → label reads "1 tag will be merged".
+- The pill stays in place in the row (it is not moved to a separate area or removed from the row) — only its style and the count label change.
+
+## Bug fix bundled in
+
+`TagService.mergeTags` (`src/services/TagService.ts:135`) takes a `sources: TagItem[]` array and a `targetName: string`. If `targetName` matches the name of one of the entries in `sources`, `addTarget` correctly skips re-adding it to work item tags (already present), but **Phase 2 still deletes it**, because it's in `sources` and its add succeeded — i.e. the destination tag itself gets deleted. This bug already exists today (reachable by manually typing a source's exact name into the target field) and becomes directly reachable via a single click once pills are selectable.
+
+**Fix:** immediately before calling `runMergeJobs`/`tagService.mergeTags`, filter out any entry from `sources` whose name matches `targetName` case-insensitively. This belongs in `TagManagerApp.tsx` at the `onConfirm` call site (`src/app/TagManagerApp.tsx:325`), since that's where `dialog.sources` and the confirmed `targetName` are both available:
+
+```tsx
+onConfirm={(targetName) =>
+  runMergeJobs(
+    dialog.sources.filter(
+      (s) => s.name.toLowerCase() !== targetName.toLowerCase()
+    ),
+    targetName
+  )
+}
+```
+
+## Edge cases
+
+- If the user deselects the only chosen target (clicks the selected pill again) and the field is now empty, `isValid` is `false` and the Merge button remains disabled, same as today's empty-input behavior.
+- If, after filtering, zero sources remain (e.g. user selected only one tag total and clicked it as target), the Merge button should still be disabled — merging requires at least one other tag to fold in. `isValid` needs to additionally check that at least one source remains after the target-name filter, not just that `trimmed.length > 0`.
+- Suggestions list below already excludes `sources` by id (existing filter, line 27-30) — no change needed there, since a source can only become the target via pill click, not via the suggestion list.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/app/MergeDialog.tsx` | Make source pills clickable/selectable; add selected-state styling; recompute the count label; extend `isValid` to require ≥1 remaining source after excluding the target |
+| `src/app/TagManagerApp.tsx` | Filter `dialog.sources` by `targetName` before calling `runMergeJobs`, at the `MergeDialog`'s `onConfirm` call site |
+
+## Verification
+
+1. Select 2 tags, open Merge. Click the first pill — it switches to filled/checkmark style, the count label updates to "1 tag will be merged", and the target field shows that tag's name.
+2. Click the same pill again — it deselects, count label reverts to "2 tags will be merged", target field clears, Merge button disables.
+3. Click the first pill, then type a different, unrelated tag name in the text field — the pill reverts to unselected style (since `targetName` no longer matches it), and the typed name becomes the target.
+4. Select exactly 2 tags, click one as target, click Merge — confirm only the *other* tag is merged and deleted, and the target tag is not deleted (validates the `TagService.mergeTags` self-deletion bug fix).
+5. Select exactly 1 tag, open Merge, click it as the target — confirm Merge button stays disabled (no other source remains to merge).
+6. Keyboard: tab to a pill, press Enter/Space — confirm it selects the same as a click.
+7. Verify light and dark theme — filled pill variant should be legible in both.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tag-toolkit-azure-boards",
-  "version": "0.2.7",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tag-toolkit-azure-boards",
-      "version": "0.2.7",
+      "version": "1.0.0",
       "dependencies": {
         "azure-devops-extension-api": "^4.270.0",
         "azure-devops-extension-sdk": "^4.2.0",

--- a/src/app/MergeDialog.test.tsx
+++ b/src/app/MergeDialog.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
+import { PillVariant } from "azure-devops-ui/Pill";
 
 import { MergeDialog } from "./MergeDialog";
 
@@ -63,5 +64,101 @@ describe("MergeDialog", () => {
     expect(screen.getByText("platform")).toBeInTheDocument();
     expect(screen.getByText("frontend")).toBeInTheDocument();
     expect(screen.getByText("old-tag")).toBeInTheDocument();
+  });
+
+  it("selects a source tag as the target when its pill is clicked", () => {
+    const onConfirm = jest.fn();
+    const twoSources = [
+      { id: "1", name: "one", url: "u" },
+      { id: "2", name: "two", url: "u" },
+    ];
+
+    render(
+      <MergeDialog
+        sources={twoSources}
+        allTags={[]}
+        onConfirm={onConfirm}
+        onCancel={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "one" }));
+
+    expect(
+      screen.getByPlaceholderText("Type to search or create a tag")
+    ).toHaveValue("one");
+    expect(screen.getByText("1 tag will be merged")).toBeInTheDocument();
+
+    const targetPill = screen.getByText("one").closest('[data-testid="pill"]');
+    expect(targetPill).toHaveAttribute("data-variant", String(PillVariant.standard));
+    expect(targetPill).toHaveAttribute("data-icon", "CheckMark");
+
+    fireEvent.click(screen.getByRole("button", { name: "Merge" }));
+    expect(onConfirm).toHaveBeenCalledWith("one");
+  });
+
+  it("deselects a source pill when it is clicked again", () => {
+    const twoSources = [
+      { id: "1", name: "one", url: "u" },
+      { id: "2", name: "two", url: "u" },
+    ];
+
+    render(
+      <MergeDialog
+        sources={twoSources}
+        allTags={[]}
+        onConfirm={jest.fn()}
+        onCancel={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "one" }));
+    fireEvent.click(screen.getByRole("button", { name: "one" }));
+
+    expect(
+      screen.getByPlaceholderText("Type to search or create a tag")
+    ).toHaveValue("");
+    expect(screen.getByText("2 tags will be merged")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Merge" })).toBeDisabled();
+  });
+
+  it("disables Merge when the only source is selected as its own target", () => {
+    const oneSource = [{ id: "1", name: "solo", url: "u" }];
+
+    render(
+      <MergeDialog
+        sources={oneSource}
+        allTags={[]}
+        onConfirm={jest.fn()}
+        onCancel={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "solo" }));
+
+    expect(screen.getByRole("button", { name: "Merge" })).toBeDisabled();
+  });
+
+  it("supports selecting a source pill via the keyboard", () => {
+    const onConfirm = jest.fn();
+    const twoSources = [
+      { id: "1", name: "one", url: "u" },
+      { id: "2", name: "two", url: "u" },
+    ];
+
+    render(
+      <MergeDialog
+        sources={twoSources}
+        allTags={[]}
+        onConfirm={onConfirm}
+        onCancel={jest.fn()}
+      />
+    );
+
+    fireEvent.keyDown(screen.getByRole("button", { name: "one" }), { key: "Enter" });
+
+    expect(
+      screen.getByPlaceholderText("Type to search or create a tag")
+    ).toHaveValue("one");
   });
 });

--- a/src/app/MergeDialog.tsx
+++ b/src/app/MergeDialog.tsx
@@ -38,10 +38,16 @@ export const MergeDialog: React.FC<MergeDialogProps> = ({
 
   const isNewTag =
     trimmed.length > 0 &&
-    !allTags.some((t) => t.name.toLowerCase() === trimmed.toLowerCase());
+    !allTags.some((t) => t.name.toLowerCase() === trimmed.toLowerCase()) &&
+    !sources.some((t) => t.name.toLowerCase() === trimmed.toLowerCase());
 
   const totalItems = suggestions.length + (isNewTag ? 1 : 0);
-  const isValid = trimmed.length > 0;
+
+  const targetIsSource = sources.some(
+    (t) => t.name.toLowerCase() === trimmed.toLowerCase()
+  );
+  const remainingSourceCount = targetIsSource ? sources.length - 1 : sources.length;
+  const isValid = trimmed.length > 0 && remainingSourceCount > 0;
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTargetName(e.target.value);
@@ -51,6 +57,24 @@ export const MergeDialog: React.FC<MergeDialogProps> = ({
   const selectSuggestion = (name: string) => {
     setTargetName(name);
     setHighlightedIndex(-1);
+  };
+
+  const handlePillClick = (name: string) => {
+    if (trimmed.toLowerCase() === name.toLowerCase()) {
+      setTargetName("");
+    } else {
+      selectSuggestion(name);
+    }
+  };
+
+  const handlePillKeyDown = (
+    e: React.KeyboardEvent<HTMLDivElement>,
+    name: string
+  ) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handlePillClick(name);
+    }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -102,19 +126,35 @@ export const MergeDialog: React.FC<MergeDialogProps> = ({
           margin: "12px 0 8px",
         }}
       >
-        {sources.length} tag{sources.length !== 1 ? "s" : ""} will be merged
+        {remainingSourceCount} tag{remainingSourceCount !== 1 ? "s" : ""} will be merged
       </div>
       <div style={{ display: "flex", flexWrap: "wrap", gap: "6px", margin: "0 0 16px" }}>
-        {sources.map((t) => (
-          <Pill
-            key={t.id}
-            size={PillSize.regular}
-            variant={PillVariant.outlined}
-            iconProps={{ iconName: "Tag" }}
-          >
-            {t.name}
-          </Pill>
-        ))}
+        {sources.map((t) => {
+          const isTarget = t.name.toLowerCase() === trimmed.toLowerCase();
+          return (
+            <div
+              key={t.id}
+              role="button"
+              tabIndex={0}
+              onClick={() => handlePillClick(t.name)}
+              onKeyDown={(e) => handlePillKeyDown(e, t.name)}
+              title={
+                isTarget
+                  ? "Target — other tags will be merged into this one"
+                  : undefined
+              }
+              style={{ cursor: "pointer", display: "inline-flex" }}
+            >
+              <Pill
+                size={PillSize.regular}
+                variant={isTarget ? PillVariant.standard : PillVariant.outlined}
+                iconProps={{ iconName: isTarget ? "CheckMark" : "Tag" }}
+              >
+                {t.name}
+              </Pill>
+            </div>
+          );
+        })}
       </div>
       <FormItem label="Target tag">
         <div>

--- a/src/app/MergeDialog.tsx
+++ b/src/app/MergeDialog.tsx
@@ -113,7 +113,7 @@ export const MergeDialog: React.FC<MergeDialogProps> = ({
       onDismiss={onCancel}
     >
       <MessageCard severity={MessageCardSeverity.Warning}>
-        The following tag{sources.length !== 1 ? "s" : ""} will be merged into
+        The following tag{remainingSourceCount !== 1 ? "s" : ""} will be merged into
         the target and removed from the project.
       </MessageCard>
       <div
@@ -135,6 +135,7 @@ export const MergeDialog: React.FC<MergeDialogProps> = ({
             <div
               key={t.id}
               role="button"
+              aria-pressed={isTarget}
               tabIndex={0}
               onClick={() => handlePillClick(t.name)}
               onKeyDown={(e) => handlePillKeyDown(e, t.name)}

--- a/src/app/MergeDialog.tsx
+++ b/src/app/MergeDialog.tsx
@@ -62,6 +62,7 @@ export const MergeDialog: React.FC<MergeDialogProps> = ({
   const handlePillClick = (name: string) => {
     if (trimmed.toLowerCase() === name.toLowerCase()) {
       setTargetName("");
+      setHighlightedIndex(-1);
     } else {
       selectSuggestion(name);
     }
@@ -113,8 +114,9 @@ export const MergeDialog: React.FC<MergeDialogProps> = ({
       onDismiss={onCancel}
     >
       <MessageCard severity={MessageCardSeverity.Warning}>
-        The following tag{remainingSourceCount !== 1 ? "s" : ""} will be merged into
-        the target and removed from the project.
+        {targetIsSource
+          ? `The following tag${remainingSourceCount !== 1 ? "s" : ""} will be merged into the target and removed. The target tag will be kept.`
+          : `The following tag${remainingSourceCount !== 1 ? "s" : ""} will be merged into the target and removed from the project.`}
       </MessageCard>
       <div
         style={{

--- a/src/app/TagManagerApp.test.tsx
+++ b/src/app/TagManagerApp.test.tsx
@@ -7,6 +7,7 @@ const mockTagService = {
   deleteTagById: jest.fn(),
   renameTagById: jest.fn(),
   mergeTag: jest.fn(),
+  mergeTags: jest.fn(),
 };
 
 jest.mock("../services/TagService", () => ({
@@ -39,6 +40,7 @@ describe("TagManagerApp", () => {
       affectedCount: 1,
       workItemIds: [1],
     });
+    mockTagService.mergeTags.mockResolvedValue({ succeeded: [], failed: [] });
 
     // Default: no cache, not stale (no auto-refresh)
     mockTagCountCacheService.getCache.mockResolvedValue(null);
@@ -85,6 +87,39 @@ describe("TagManagerApp", () => {
     expect(mergeIndex).toBeGreaterThan(-1);
     expect(deleteIndex).toBeGreaterThan(-1);
     expect(mergeIndex).toBeLessThan(deleteIndex);
+  });
+
+  it("excludes the tag selected as target from the sources sent to mergeTags", async () => {
+    mockTagService.getAllTags.mockResolvedValue([
+      { id: "1", name: "one", url: "u" },
+      { id: "2", name: "two", url: "u" },
+    ]);
+
+    render(<TagManagerApp />);
+
+    await waitFor(() => {
+      expect(screen.getByText("one")).toBeInTheDocument();
+    });
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    fireEvent.click(checkboxes[1]); // row for "one"
+    fireEvent.click(checkboxes[2]); // row for "two"
+
+    fireEvent.click(screen.getByRole("button", { name: /^Merge/ }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "one" }));
+    fireEvent.click(screen.getByRole("button", { name: "Merge" }));
+
+    await waitFor(() => {
+      expect(mockTagService.mergeTags).toHaveBeenCalledWith(
+        [{ id: "2", name: "two", url: "u" }],
+        "one"
+      );
+    });
   });
 
   it("shows an error card when loading fails", async () => {

--- a/src/app/TagManagerApp.tsx
+++ b/src/app/TagManagerApp.tsx
@@ -322,7 +322,14 @@ export const TagManagerApp: React.FC = () => {
         <MergeDialog
           sources={dialog.sources}
           allTags={tags}
-          onConfirm={(targetName) => runMergeJobs(dialog.sources, targetName)}
+          onConfirm={(targetName) =>
+            runMergeJobs(
+              dialog.sources.filter(
+                (s) => s.name.toLowerCase() !== targetName.toLowerCase()
+              ),
+              targetName
+            )
+          }
           onCancel={() => setDialog(null)}
         />
       )}

--- a/src/test/mocks/modules/azureDevopsUi.tsx
+++ b/src/test/mocks/modules/azureDevopsUi.tsx
@@ -274,4 +274,8 @@ export const Pill: React.FC<
     iconProps?: { iconName: string };
     className?: string;
   }>
-> = ({ children }) => <span data-testid="pill">{children}</span>;
+> = ({ children, variant, iconProps }) => (
+  <span data-testid="pill" data-variant={variant} data-icon={iconProps?.iconName}>
+    {children}
+  </span>
+);


### PR DESCRIPTION
This pull request introduces a new click-to-select target feature in the Merge Tags dialog, allowing users to select a merge target by clicking one of the source tag pills, improving usability and accessibility. It also fixes a longstanding bug where the target tag could be deleted if selected as its own target, and updates validation logic to prevent merging when no valid sources remain. The changes are covered by new and updated tests and documented in a detailed design spec.

**Merge dialog UI/UX improvements:**

* Source tag pills in `MergeDialog` are now clickable and keyboard-accessible, allowing users to select or deselect a tag as the merge target directly from the pill row. The selected pill is styled differently and displays a checkmark. The count label updates to exclude the selected target. Validation ensures at least one source remains after selecting a target. (`src/app/MergeDialog.tsx`, `src/app/MergeDialog.test.tsx`) [[1]](diffhunk://#diff-78b0ea023cda7922ba6d3f67fb1c250030945a41d370fb12555335724bbf4600L41-R50) [[2]](diffhunk://#diff-78b0ea023cda7922ba6d3f67fb1c250030945a41d370fb12555335724bbf4600R62-R79) [[3]](diffhunk://#diff-78b0ea023cda7922ba6d3f67fb1c250030945a41d370fb12555335724bbf4600L92-R116) [[4]](diffhunk://#diff-78b0ea023cda7922ba6d3f67fb1c250030945a41d370fb12555335724bbf4600L105-R158) [[5]](diffhunk://#diff-066bf4f14757c4d6820ef002dce49b013cca86f3e180398a9ba831fedf95e7b5R3) [[6]](diffhunk://#diff-066bf4f14757c4d6820ef002dce49b013cca86f3e180398a9ba831fedf95e7b5R68-R163) [[7]](diffhunk://#diff-30280bdd16e09dea67dfba61a66aff03a4d8378cebaf24c2a5188a3e3264817dL277-R281)

**Bug fix:**

* Fixes the bug where the target tag could be deleted if it matches one of the sources by ensuring the selected target is filtered out of the sources array before merging. (`src/app/TagManagerApp.tsx`)

**Validation and edge case handling:**

* The Merge button is now disabled if, after selecting a target, no other sources remain to merge (e.g., only one tag selected and chosen as target). (`src/app/MergeDialog.tsx`)

**Testing:**

* Adds and updates tests to cover pill selection/deselection, keyboard interaction, validation, and ensures the target is excluded from sources in merge operations. (`src/app/MergeDialog.test.tsx`, `src/app/TagManagerApp.test.tsx`, `src/test/mocks/modules/azureDevopsUi.tsx`) [[1]](diffhunk://#diff-066bf4f14757c4d6820ef002dce49b013cca86f3e180398a9ba831fedf95e7b5R68-R163) [[2]](diffhunk://#diff-f5422c0e8cad41499e9089f9bc86ee3ee24277c31fae2d05eb3f5d0128942845R92-R124) [[3]](diffhunk://#diff-30280bdd16e09dea67dfba61a66aff03a4d8378cebaf24c2a5188a3e3264817dL277-R281)

**Documentation:**

* Adds a comprehensive design spec describing the new click-to-select target feature, expected behaviors, bug fix, and edge cases. (`docs/superpowers/specs/2026-07-04-merge-target-pill-design.md`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Merge dialog source tags can now be clicked or keyboard-operated to choose the merge target.
  * The selected target is visually highlighted, and the merge count updates to reflect only the remaining tags.

* **Bug Fixes**
  * Prevents merging a tag into itself by excluding the selected target from the final merge sources.
  * Merge is disabled when selecting a target leaves no other tags to merge.

* **Tests**
  * Added coverage for click, keyboard, deselect, and filtered merge-source behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->